### PR TITLE
Wrap DKIM signature headers appropriately

### DIFF
--- a/lib/postal/dkim_header.rb
+++ b/lib/postal/dkim_header.rb
@@ -17,7 +17,7 @@ module Postal
     end
 
     def dkim_header
-      "DKIM-Signature: v=1;" + dkim_properties + signature
+      "DKIM-Signature: v=1; " + dkim_properties.join("\r\n\t") + signature.scan(/.{1,72}/).join("\r\n\t")
     end
 
     private
@@ -96,16 +96,18 @@ module Postal
     end
 
     def dkim_properties
-      String.new.tap do |header|
-        header << " a=rsa-sha256; c=relaxed/relaxed;"
-        header << " d=#{@domain_name}; s=#{@dkim_identifier}; t=#{Time.now.utc.to_i};"
-        header << " bh=#{body_hash}; h=#{header_names.join(':')};"
-        header << " b="
+      Array.new.tap do |header|
+        header << "a=rsa-sha256; c=relaxed/relaxed;"
+        header << "d=#{@domain_name};"
+        header << "s=#{@dkim_identifier}; t=#{Time.now.utc.to_i};"
+        header << "bh=#{body_hash};"
+        header << "h=#{header_names.join(':')};"
+        header << "b="
       end
     end
 
     def dkim_header_for_signing
-      "dkim-signature:v=1;" + dkim_properties
+      "dkim-signature:v=1; #{dkim_properties.join(' ')}"
     end
 
     def signable_header_string

--- a/spec/lib/postal/dkim_header_spec.rb
+++ b/spec/lib/postal/dkim_header_spec.rb
@@ -20,11 +20,12 @@ describe Postal::DKIMHeader do
       allow(domain).to receive(:dkim_key).and_return(OpenSSL::PKey::RSA.new(frontmatter['private_key']))
       allow(domain).to receive(:dkim_identifier).and_return(frontmatter['dkim_identifier'])
 
-      expectation = "DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; "  \
-                    "d=#{frontmatter['domain']}; s=#{frontmatter['dkim_identifier']}; t=#{mocked_time.to_i}; " \
-                    "bh=#{frontmatter['bh']}; "\
-                    "h=#{frontmatter['headers']}; " \
-                    "b=#{frontmatter['b']}"
+      expectation = "DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;\r\n"  \
+                    "\td=#{frontmatter['domain']};\r\n" \
+                    "\ts=#{frontmatter['dkim_identifier']}; t=#{mocked_time.to_i};\r\n" \
+                    "\tbh=#{frontmatter['bh']};\r\n"\
+                    "\th=#{frontmatter['headers']};\r\n" \
+                    "\tb=#{frontmatter['b'].scan(/.{1,72}/).join("\r\n\t")}"
 
       header = described_class.new(domain, email)
 


### PR DESCRIPTION
Closes #339

This resolves an issue with `DKIM-Signature` headers not being wrapped correctly. This will now wrap it at 72 characters and splits the key components over multiple lines.