### PR TITLE
fix(dkim): timing race condition in signing process

### DIFF
--- a/lib/postal/dkim_header.rb
+++ b/lib/postal/dkim_header.rb
@@ -13,6 +13,7 @@ module Postal
       end
       @domain = domain
       @message = message
+      @time = Time.now
       @raw_headers, @raw_body = @message.gsub(/\r?\n/, "\r\n").split(/\r\n\r\n/, 2)
     end
 
@@ -99,7 +100,7 @@ module Postal
       Array.new.tap do |header|
         header << "a=rsa-sha256; c=relaxed/relaxed;"
         header << "d=#{@domain_name};"
-        header << "s=#{@dkim_identifier}; t=#{Time.now.utc.to_i};"
+        header << "s=#{@dkim_identifier}; t=#{@time.utc.to_i};"
         header << "bh=#{body_hash};"
         header << "h=#{header_names.join(':')};"
         header << "b="


### PR DESCRIPTION
I've had a problem where `dkim_properties` is called twice,
but returned the a different timestamp. This due to a second
being passed, or it was just on the edge of the last second.

The fact that 2 different times were returned, resulted in a 
different time in the signature and a different time in the `t=`
DKIM header.

I don't have any experience with Ruby. I'm attempting to 
test this on our prod environment, as this is unfortunately 
seen more often than I'd like it to happen :).