### PR TITLE
Update client.rb

### DIFF
--- a/lib/postal/smtp_server/client.rb
+++ b/lib/postal/smtp_server/client.rb
@@ -105,7 +105,10 @@ module Postal
       private
 
       def resolve_hostname
-        @hostname = Resolv.new.getname(@ip_address) rescue @ip_address
+        Resolv::DNS.open do |dns|
+          dns.timeouts = [10,5]
+          @hostname = dns.getname(@ip_address) rescue @ip_address
+        end
       end
 
       def proxy(data)


### PR DESCRIPTION
Added timeouts to resolve reverse dns requests, this prevents, if one of two dns servers are offline (and entry does not exists), a "Broken Pipe" appears in smtp log, and mailing got interrupted beceause one dns server is not reachable.