### PR TITLE
Handling large smtp error messages over the varchar(512) limit

### DIFF
--- a/lib/postal/message_db/delivery.rb
+++ b/lib/postal/message_db/delivery.rb
@@ -50,7 +50,7 @@ module Postal
           :message => @message.webhook_hash,
           :status => self.status,
           :details => self.details,
-          :output => self.output.to_s.force_encoding('UTF-8').scrub,
+          :output => self.output.to_s.force_encoding('UTF-8').scrub.first(512),
           :sent_with_ssl => self.sent_with_ssl,
           :timestamp => @attributes['timestamp'],
           :time => self.time


### PR DESCRIPTION
Some smtp servers have very long status code messages, if its greater then 512 chars - Postal throughs a Mysql error. Since the output column is varchar(512), lets strip off just 512 chars so we dont get an error on the mysql insert.

More details here: https://github.com/postalserver/postal/discussions/2185