### PR TITLE
Feat/add show message content config parameter

### DIFF
--- a/app/views/messages/_message_header.html.haml
+++ b/app/views/messages/_message_header.html.haml
@@ -29,10 +29,11 @@
   %ul
     %li.navBar__item= link_to "Properties", organization_server_message_path(organization, @server, @message.id), :class => ['navBar__link', active_nav == :properties ? 'is-active' : '']
     %li.navBar__item= link_to "Activity", activity_organization_server_message_path(organization, @server, @message.id), :class => ['navBar__link', active_nav == :activity ? 'is-active' : '']
-    %li.navBar__item= link_to "Headers", headers_organization_server_message_path(organization, @server, @message.id), :class => ['navBar__link', active_nav == :headers ? 'is-active' : '']
-    %li.navBar__item= link_to "Spam Checks", spam_checks_organization_server_message_path(organization, @server, @message.id), :class => ['navBar__link', active_nav == :spam_checks ? 'is-active' : '']
-    %li.navBar__item= link_to "Plain Text", plain_organization_server_message_path(organization, @server, @message.id), :class => ['navBar__link', active_nav == :plain ? 'is-active' : '']
-    %li.navBar__item= link_to "HTML", html_organization_server_message_path(organization, @server, @message.id), :class => ['navBar__link', active_nav == :html ? 'is-active' : '']
-    %li.navBar__item= link_to "Attachments", attachments_organization_server_message_path(organization, @server, @message.id), :class => ['navBar__link', active_nav == :attachments ? 'is-active' : '']
-    - if @message.raw_message?
-      %li.navBar__item= link_to "Download", download_organization_server_message_path(organization, @server, @message.id), :data => {:turbolinks => 'false'}, :class =>'navBar__link'
+    - if Postal.config.general.show_message_content
+      %li.navBar__item= link_to "Headers", headers_organization_server_message_path(organization, @server, @message.id), :class => ['navBar__link', active_nav == :headers ? 'is-active' : '']
+      %li.navBar__item= link_to "Spam Checks", spam_checks_organization_server_message_path(organization, @server, @message.id), :class => ['navBar__link', active_nav == :spam_checks ? 'is-active' : '']
+      %li.navBar__item= link_to "Plain Text", plain_organization_server_message_path(organization, @server, @message.id), :class => ['navBar__link', active_nav == :plain ? 'is-active' : '']
+      %li.navBar__item= link_to "HTML", html_organization_server_message_path(organization, @server, @message.id), :class => ['navBar__link', active_nav == :html ? 'is-active' : '']
+      %li.navBar__item= link_to "Attachments", attachments_organization_server_message_path(organization, @server, @message.id), :class => ['navBar__link', active_nav == :attachments ? 'is-active' : '']
+      - if @message.raw_message?
+        %li.navBar__item= link_to "Download", download_organization_server_message_path(organization, @server, @message.id), :data => {:turbolinks => 'false'}, :class =>'navBar__link'

--- a/config/postal.defaults.yml
+++ b/config/postal.defaults.yml
@@ -17,6 +17,7 @@ general:
   use_local_ns_for_domains: false
   default_spam_threshold: 5.0
   default_spam_failure_threshold: 20.0
+  show_message_content: true
 
 web_server:
   bind_address: 127.0.0.1

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,13 +27,15 @@ Rails.application.routes.draw do
         get :outgoing, :on => :collection
         get :held, :on => :collection
         get :activity, :on => :member
-        get :plain, :on => :member
-        get :html, :on => :member
-        get :html_raw, :on => :member
-        get :attachments, :on => :member
-        get :headers, :on => :member
-        get :attachment, :on => :member
-        get :download, :on => :member
+        if Postal.config.general.show_message_content
+         get :plain, :on => :member
+         get :html, :on => :member
+         get :html_raw, :on => :member
+         get :attachments, :on => :member
+         get :headers, :on => :member
+         get :attachment, :on => :member
+         get :download, :on => :member
+        end
         get :spam_checks, :on => :member
         post :retry, :on => :member
         post :cancel_hold, :on => :member


### PR DESCRIPTION
I am trying to use Postal for one of my client to manage our business needs but we don't want to display messages information as it is sensitive data.

I would like to add a private/public mode to Postal in order to not display sensitive content from emails such as attachments, plain text, plain html. 

Using one new variable in the file `config/postal.defaults.yml`

`show_message_content: false` to not display sensitive data from incoming and outgoing messages


**show_message_content: false**

<img width="1255" alt="Capture d’écran 2022-12-12 à 13 48 33" src="https://user-images.githubusercontent.com/17969052/207063661-97a0d612-3269-44ab-aec1-4f16392cbe0d.png">
<img width="1242" alt="Capture d’écran 2022-12-12 à 13 50 04" src="https://user-images.githubusercontent.com/17969052/207063665-4111f96c-4cb2-4d0d-b799-9bf24b4c4cde.png">


**show_message_content: true**
<img width="1249" alt="Capture d’écran 2022-12-12 à 15 00 37" src="https://user-images.githubusercontent.com/17969052/207064271-d3a40088-9376-4bf3-9f6a-e6fdb152f75b.png">

