### PR TITLE
fix(docker): fix libmariadbclient-dev install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
   software-properties-common dirmngr apt-transport-https \
-  && apt-key adv --fetch-keys 'https://mariadb.org/mariadb_release_signing_key.asc' \
-  && add-apt-repository 'deb [arch=amd64,arm64,ppc64el] https://mirrors.xtom.nl/mariadb/repo/10.6/debian buster main' \
   && (curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -) \
   && (echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list) \
   && (curl -sL https://deb.nodesource.com/setup_12.x | bash -) \


### PR DESCRIPTION
uses debian repos instead of the broken mariadb-mirror

---

Looking at the current production-2.1.1 image, **this mirror appears to not have been used anyhow?**

```
@wadabum ➜ /workspaces/postal (fix-ci-mariadbclient) $ docker run --pull --rm --entrypoint "" ghcr.io/postalserver/postal:2.1.1 bash -c " dpkg -l | grep mariadb"
ii  libmariadb-dev                     1:10.3.31-0+deb10u1          amd64        MariaDB database development files
ii  libmariadb-dev-compat:amd64        1:10.3.31-0+deb10u1          amd64        MariaDB Connector/C, compatibility symlinks
ii  libmariadb3:amd64                  1:10.3.31-0+deb10u1          amd64        MariaDB database client library
ii  libmariadbclient-dev:amd64         1:10.3.31-0+deb10u1          amd64        MariaDB database development files (transitional package)
ii  mariadb-common                     1:10.3.31-0+deb10u1          all          MariaDB common metapackage
```
**vs.**
```
@wadabum ➜ /workspaces/postal (fix-ci-mariadbclient) $ docker build -t postaltest . && docker run --rm --entrypoint "" postaltest bash -c " dpkg -l | grep mariadb"
[+] Building 0.6s (20/20) FINISHED                                                                                                                                                                                                                                                                                    
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                                             0.1s
 => => transferring dockerfile: 35B                                                                                                                                                                                                                                                                              0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                                0.1s
 => => transferring context: 35B                                                                                                                                                                                                                                                                                 0.0s
 => [internal] load metadata for docker.io/library/ruby:2.6-buster                                                                                                                                                                                                                                               0.0s
 => [base  1/13] FROM docker.io/library/ruby:2.6-buster                                                                                                                                                                                                                                                          0.0s
 => [internal] load build context                                                                                                                                                                                                                                                                                0.1s
 => => transferring context: 37.53kB                                                                                                                                                                                                                                                                             0.0s
 => CACHED [base  2/13] RUN apt-get update   && apt-get install -y --no-install-recommends   software-properties-common dirmngr apt-transport-https   && (curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -)   && (echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources  0.0s
 => CACHED [base  3/13] RUN apt-get update &&   apt-get install -y --no-install-recommends   build-essential    netcat   curl   libmariadbclient-dev   nano   nodejs                                                                                                                                             0.0s
 => CACHED [base  4/13] RUN setcap 'cap_net_bind_service=+ep' /usr/local/bin/ruby                                                                                                                                                                                                                                0.0s
 => CACHED [base  5/13] RUN useradd -r -d /opt/postal -m -s /bin/bash -u 999 postal                                                                                                                                                                                                                              0.0s
 => CACHED [base  6/13] RUN mkdir -p /opt/postal/app /opt/postal/config                                                                                                                                                                                                                                          0.0s
 => CACHED [base  7/13] WORKDIR /opt/postal/app                                                                                                                                                                                                                                                                  0.0s
 => CACHED [base  8/13] RUN gem install bundler -v 2.1.4 --no-doc                                                                                                                                                                                                                                                0.0s
 => CACHED [base  9/13] COPY Gemfile Gemfile.lock ./                                                                                                                                                                                                                                                             0.0s
 => CACHED [base 10/13] RUN bundle install -j 4                                                                                                                                                                                                                                                                  0.0s
 => CACHED [base 11/13] COPY ./docker/wait-for.sh /docker-entrypoint.sh                                                                                                                                                                                                                                          0.0s
 => CACHED [base 12/13] COPY --chown=postal . .                                                                                                                                                                                                                                                                  0.0s
 => CACHED [base 13/13] RUN echo unspecified > VERSION                                                                                                                                                                                                                                                           0.0s
 => CACHED [prod 1/2] RUN POSTAL_SKIP_CONFIG_CHECK=1 RAILS_GROUPS=assets bundle exec rake assets:precompile                                                                                                                                                                                                      0.0s
 => CACHED [prod 2/2] RUN touch /opt/postal/app/public/assets/.prebuilt                                                                                                                                                                                                                                          0.0s
 => exporting to image                                                                                                                                                                                                                                                                                           0.2s
 => => exporting layers                                                                                                                                                                                                                                                                                          0.0s
 => => writing image sha256:c47af3f2ceabb6b0cdb9a93f11df7a424fa16a21f00ff910352479a5f5217a3a                                                                                                                                                                                                                     0.0s
 => => naming to docker.io/library/postaltest                                                                                                                                                                                                                                                                    0.0s
ii  libmariadb-dev                     1:10.3.36-0+deb10u2          amd64        MariaDB database development files
ii  libmariadb-dev-compat:amd64        1:10.3.36-0+deb10u2          amd64        MariaDB Connector/C, compatibility symlinks
ii  libmariadb3:amd64                  1:10.3.36-0+deb10u2          amd64        MariaDB database client library
ii  libmariadbclient-dev:amd64         1:10.3.36-0+deb10u2          amd64        MariaDB database development files (transitional package)
ii  mariadb-common                     1:10.3.34-0+deb10u1          all          MariaDB common metapackage
```
so its even a upgrade =)

---

Hope this helps in easing a release for https://github.com/postalserver/postal/pull/2304 / https://github.com/postalserver/postal/issues/1182#issuecomment-1365544419 🙈