### PR TITLE
Add null check for output variable

### DIFF
--- a/lib/postal/message_db/delivery.rb
+++ b/lib/postal/message_db/delivery.rb
@@ -48,7 +48,7 @@ module Postal
           message: @message.webhook_hash,
           status: status,
           details: details,
-          output: output.to_s.force_encoding("UTF-8").scrub.truncate(512),
+          output: (output || '').to_s.force_encoding('UTF-8').scrub.truncate(512),
           sent_with_ssl: sent_with_ssl,
           timestamp: @attributes["timestamp"],
           time: time


### PR DESCRIPTION
Seems that he output value can be null and the check therefore is missing.

On some other places in the code the output variable is null checked. I'm no ruby developer, but i didn't find the place where the output value is set.

Hopefully a experienced developer can check the PR. This is really an annoying bug, which leads to multiple executions of webhook triggers.

fixes #2153