### PR TITLE
#1698 Add ActionMailbox sendgrid endpoint encoding format to http endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: docker/build-push-action@v4
         with:
           push: true
-          tags: ghcr.io/postalserver/postal:ci-${{ github.sha }}
+          tags: ghcr.io/quorak/postal:ci-${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           target: ci
@@ -53,16 +53,16 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - run: docker-compose pull
         env:
-          POSTAL_IMAGE: ghcr.io/postalserver/postal:ci-${{ github.sha }}
+          POSTAL_IMAGE: ghcr.io/quorak/postal:ci-${{ github.sha }}
       - run: docker-compose run postal sh -c 'bundle exec rspec'
         env:
-          POSTAL_IMAGE: ghcr.io/postalserver/postal:ci-${{ github.sha }}
+          POSTAL_IMAGE: ghcr.io/quorak/postal:ci-${{ github.sha }}
 
   release-branch:
     name: Release (branch)
     runs-on: ubuntu-latest
     needs: [build]
-    if: startsWith(github.ref, 'refs/heads/')
+    if: startsWith(github.ref, 'refs/heads/main')
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2
@@ -81,8 +81,8 @@ jobs:
         with:
           push: true
           tags: |
-            ghcr.io/postalserver/postal:${{ steps.tag.outputs.tag }}
-            ghcr.io/postalserver/postal:commit-${{ github.sha }}
+            ghcr.io/quorak/postal:${{ steps.tag.outputs.tag }}
+            ghcr.io/quorak/postal:commit-${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           target: full
@@ -90,8 +90,7 @@ jobs:
   publish-image:
     name: Publish Image
     runs-on: ubuntu-latest
-    needs: [build, test, release-please]
-    if: ${{ needs.release-please.outputs.release_created }}
+    needs: [build, test]
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2
@@ -104,8 +103,8 @@ jobs:
         with:
           push: true
           tags: |
-            ghcr.io/postalserver/postal:stable
-            ghcr.io/postalserver/postal:${{ needs.release-please.outputs.version }}
+            ghcr.io/quorak/postal:stable
+            ghcr.io/quorak/postal:${{ needs.release-please.outputs.version }}
           cache-from: type=local,src=/cache/krystal-identity
           cache-to: type=local,dest=/cache/krystal-identity,mode=max
           target: full

--- a/app/models/http_endpoint.rb
+++ b/app/models/http_endpoint.rb
@@ -29,7 +29,7 @@ class HTTPEndpoint < ApplicationRecord
   has_many :routes, as: :endpoint
   has_many :additional_route_endpoints, dependent: :destroy, as: :endpoint
 
-  ENCODINGS = ["BodyAsJSON", "FormData"]
+  ENCODINGS = ["BodyAsJSON", "FormData", "SendgridCompatibleBodyAsJson"]
   FORMATS = ["Hash", "RawMessage"]
 
   before_destroy :update_routes

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,6 +50,7 @@ en:
     raw_message: Delivered as the raw message
   http_endpoint_encodings:
     body_as_json: Sent in the body as JSON
+    sendgrid_compatible_body_as_json: Sendgrid compatible Json
     form_data: Sent as form data
 
   webhook_events:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     entrypoint: ["/docker-entrypoint.sh"]
     volumes:
       - "./docker/ci-config:/config"
+    ports:
+      - 3000:3000
     environment:
       POSTAL_CONFIG_ROOT: /config
       KATAPULT_CONFIG_FILE: /ci-config.yml
@@ -23,7 +25,11 @@ services:
       MARIADB_DATABASE: postal
       MARIADB_ALLOW_EMPTY_PASSWORD: 'yes'
       MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 'yes'
+    ports:
+      - 3306:3306
 
   rabbitmq:
     image: rabbitmq:3
     restart: always
+    ports:
+      - 25672:25672


### PR DESCRIPTION
This Feature should add the capability to accept forward emails to a rails ActionMailbox http endpoint that is listening with a sendgrid configuration. see: https://guides.rubyonrails.org/action_mailbox_basics.html#sendgrid https://github.com/postalserver/postal/discussions/1698