### PR TITLE
fix: modernize docker compose references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,10 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - run: docker-compose pull
+      - run: docker compose pull
         env:
           POSTAL_IMAGE: ghcr.io/postalserver/postal:ci-${{ github.sha }}
-      - run: docker-compose run postal sh -c 'bundle exec rspec'
+      - run: docker compose run postal sh -c 'bundle exec rspec'
         env:
           POSTAL_IMAGE: ghcr.io/postalserver/postal:ci-${{ github.sha }}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   postal:
     image: ${POSTAL_IMAGE}


### PR DESCRIPTION
- `docker-compose` as a command is deprecated, updated to `docker compose` to hopefully fix [failing CI runs](<https://github.com/postalserver/postal/actions/runs/11617221668/job/32352055480>)
- [the `version` attribute in compose files is obsolete](<https://geo.thei.rs/-/whK25orI.png>)