### PR TITLE
feat: add message headers to webhook event payload

### DIFF
--- a/lib/postal/message_db/message.rb
+++ b/lib/postal/message_db/message.rb
@@ -446,7 +446,8 @@ module Postal
           subject: subject,
           timestamp: timestamp.to_f,
           spam_status: spam_status,
-          tag: tag
+          tag: tag,
+          headers: headers
         }
       end
 


### PR DESCRIPTION
It can be useful when listening for webhook events for specific messages with custom headers.