### PR TITLE
fix: oidc scopes are invalid when concatenated

### DIFF
--- a/doc/config/environment-variables.md
+++ b/doc/config/environment-variables.md
@@ -105,7 +105,7 @@ This document contains all the environment variables which are available for thi
 | `OIDC_ISSUER` | String | The OIDC issuer URL |  |
 | `OIDC_IDENTIFIER` | String | The client ID for OIDC |  |
 | `OIDC_SECRET` | String | The client secret for OIDC |  |
-| `OIDC_SCOPES` | Array of strings | Scopes to request from the OIDC server. | openid,email |
+| `OIDC_SCOPES` | Array of strings | Scopes to request from the OIDC server. | ["openid", "email"] |
 | `OIDC_UID_FIELD` | String | The field to use to determine the user's UID | sub |
 | `OIDC_EMAIL_ADDRESS_FIELD` | String | The field to use to determine the user's email address | email |
 | `OIDC_NAME_FIELD` | String | The field to use to determine the user's name | name |

--- a/doc/config/yaml.yml
+++ b/doc/config/yaml.yml
@@ -239,7 +239,8 @@ oidc:
   secret: 
   # Scopes to request from the OIDC server.
   scopes:
-    - openid,email
+    - openid
+    - email
   # The field to use to determine the user's UID
   uid_field: sub
   # The field to use to determine the user's email address

--- a/lib/postal/config_schema.rb
+++ b/lib/postal/config_schema.rb
@@ -550,7 +550,7 @@ module Postal
       string :scopes do
         description "Scopes to request from the OIDC server."
         array
-        default "openid,email"
+        default ["openid", "email"]
       end
 
       string :uid_field do


### PR DESCRIPTION
OIDC scopes should be an array of strings, the current default value seems wrong and fails with authelia, I get those logs:

```
omniauth: (oidc) Request phase initiated.
"POST /auth/oidc HTTP/1.1" 302 274 0.0484
omniauth: (oidc) Callback phase initiated.
omniauth: (oidc) Authentication failure! invalid_scope: OmniAuth::Strategies::OpenIDConnect::CallbackError, invalid_scope | The requested scope is invalid, unknown, or malformed. The OAuth 2.0 Client is not allowed to request scope 'openid,email'.
```
