### PR TITLE
Add missing uuid index on webhook_requests

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -357,6 +357,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_11_205229) do
     t.string "locked_by"
     t.datetime "locked_at", precision: nil
     t.index ["locked_by"], name: "index_webhook_requests_on_locked_by"
+    t.index ["uuid"], name: "index_webhook_requests_on_uuid"
   end
 
   create_table "webhooks", id: :integer, charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|


### PR DESCRIPTION
If you are sending a lot of emails and use webhooks, it can overload the CPU on the SQL database. The reason is that there is a SELECT query filtering on the `uuid` field in `webhook_requests`, but that field doesn't have an index.

https://github.com/postalserver/postal/blob/9c5f96ae90cf06dcd5db776806865752f667bd95/lib/postal/message_db/webhooks.rb#L21-L24

Sample slow query: `SELECT 1 AS one FROM 'webhook_requests' WHERE "webhook_requests". 'uuid' = 'a55dd28e-d...';`

This PR adds the missing index on the `uuid` field.