### PR TITLE
Authentication SMTP relays

### DIFF
--- a/app/lib/smtp_client/endpoint.rb
+++ b/app/lib/smtp_client/endpoint.rb
@@ -82,7 +82,24 @@ module SMTPClient
         @smtp_client.disable_tls
       end
 
-      @smtp_client.start(@source_ip_address ? @source_ip_address.hostname : self.class.default_helo_hostname)
+      Postal.logger.debug "=== DEBUG: starting SMTP session ==="
+      Postal.logger.debug "  ip_address: #{@ip_address}"
+      Postal.logger.debug "  port: #{@server.port}"
+      Postal.logger.debug "  helo: #{@source_ip_address ? @source_ip_address.hostname : self.class.default_helo_hostname}"
+      Postal.logger.debug "  username: #{@server.respond_to?(:username) ? @server.username.inspect : 'nil'}"
+      Postal.logger.debug "  password: #{@server.respond_to?(:password) && @server.password ? '[FILTERED]' : nil}"
+      Postal.logger.debug "  ssl_mode: #{@server.ssl_mode}"
+
+      # @smtp_client.start(@source_ip_address ? @source_ip_address.hostname : self.class.default_helo_hostname)
+      helo = @source_ip_address ? @source_ip_address.hostname : self.class.default_helo_hostname
+
+      @smtp_client.start(
+        helo,
+        @server.username,
+        @server.password,
+        @server.authentication&.to_sym # :login, :plain, :cram_md5, etc.
+      )
+
 
       @smtp_client
     end

--- a/app/lib/smtp_client/server.rb
+++ b/app/lib/smtp_client/server.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'ipaddr'
 
 module SMTPClient
   class Server
@@ -7,28 +6,11 @@ module SMTPClient
     attr_reader :hostname
     attr_reader :port
     attr_accessor :ssl_mode
-    attr_reader :username
-    attr_reader :password
-    attr_reader :authentication
 
-    def initialize(hostname, port: 25, ssl_mode: SSLModes::AUTO, username: nil, password: nil, authentication: nil)
+    def initialize(hostname, port: 25, ssl_mode: SSLModes::AUTO)
       @hostname = hostname
       @port = port
       @ssl_mode = ssl_mode
-      @username = username
-      @password = password
-      @authentication = authentication
-
-      # Debug log
-      puts "=== SMTPClient::Server Initialized ==="
-      puts "hostname: #{@hostname}"
-      puts "port: #{@port}"
-      puts "ssl_mode: #{@ssl_mode}"
-      puts "username: #{@username.inspect}"
-      puts "username decoded: #{@username ? CGI.unescape(@username) : nil}"
-      puts "password: #{@password ? '****' : nil}"
-      puts "authentication: #{@authentication}"
-      puts "===================================="
     end
 
     # Return all IP addresses for this server by resolving its hostname.
@@ -38,33 +20,16 @@ module SMTPClient
     def endpoints
       ips = []
 
-      # Vérifier si @hostname est une IP
-      is_ip = false
-      begin
-        IPAddr.new(@hostname)
-        is_ip = true
-      rescue ArgumentError
-        is_ip = false
+      DNSResolver.local.aaaa(@hostname).each do |ip|
+        ips << Endpoint.new(self, ip)
       end
 
-      if is_ip
-        # @hostname est une IP
-        ips << Endpoint.new(self, @hostname)
-      else
-        # @hostname est un nom de domaine => faire résolution DNS
-        DNSResolver.local.aaaa(@hostname).each do |ip|
-          puts "Adding AAAA endpoint: #{ip}"
-          ips << Endpoint.new(self, ip)
-        end
-
-        DNSResolver.local.a(@hostname).each do |ip|
-          puts "Adding A endpoint: #{ip}"
-          ips << Endpoint.new(self, ip)
-        end
+      DNSResolver.local.a(@hostname).each do |ip|
+        ips << Endpoint.new(self, ip)
       end
 
-      puts "Total endpoints for #{@hostname}: #{ips.size}"
       ips
     end
+
   end
 end

--- a/app/lib/smtp_client/server.rb
+++ b/app/lib/smtp_client/server.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'ipaddr'
 
 module SMTPClient
   class Server
@@ -6,11 +7,28 @@ module SMTPClient
     attr_reader :hostname
     attr_reader :port
     attr_accessor :ssl_mode
+    attr_reader :username
+    attr_reader :password
+    attr_reader :authentication
 
-    def initialize(hostname, port: 25, ssl_mode: SSLModes::AUTO)
+    def initialize(hostname, port: 25, ssl_mode: SSLModes::AUTO, username: nil, password: nil, authentication: nil)
       @hostname = hostname
       @port = port
       @ssl_mode = ssl_mode
+      @username = username
+      @password = password
+      @authentication = authentication
+
+      # Debug log
+      puts "=== SMTPClient::Server Initialized ==="
+      puts "hostname: #{@hostname}"
+      puts "port: #{@port}"
+      puts "ssl_mode: #{@ssl_mode}"
+      puts "username: #{@username.inspect}"
+      puts "username decoded: #{@username ? CGI.unescape(@username) : nil}"
+      puts "password: #{@password ? '****' : nil}"
+      puts "authentication: #{@authentication}"
+      puts "===================================="
     end
 
     # Return all IP addresses for this server by resolving its hostname.
@@ -20,16 +38,33 @@ module SMTPClient
     def endpoints
       ips = []
 
-      DNSResolver.local.aaaa(@hostname).each do |ip|
-        ips << Endpoint.new(self, ip)
+      # Vérifier si @hostname est une IP
+      is_ip = false
+      begin
+        IPAddr.new(@hostname)
+        is_ip = true
+      rescue ArgumentError
+        is_ip = false
       end
 
-      DNSResolver.local.a(@hostname).each do |ip|
-        ips << Endpoint.new(self, ip)
+      if is_ip
+        # @hostname est une IP
+        ips << Endpoint.new(self, @hostname)
+      else
+        # @hostname est un nom de domaine => faire résolution DNS
+        DNSResolver.local.aaaa(@hostname).each do |ip|
+          puts "Adding AAAA endpoint: #{ip}"
+          ips << Endpoint.new(self, ip)
+        end
+
+        DNSResolver.local.a(@hostname).each do |ip|
+          puts "Adding A endpoint: #{ip}"
+          ips << Endpoint.new(self, ip)
+        end
       end
 
+      puts "Total endpoints for #{@hostname}: #{ips.size}"
       ips
     end
-
   end
 end

--- a/app/models/smtp_endpoint.rb
+++ b/app/models/smtp_endpoint.rb
@@ -49,17 +49,17 @@ class SMTPEndpoint < ApplicationRecord
 
   def to_smtp_client_server
     puts "=== SMTPEndpoint -> SMTPClient::Server ==="
-    puts "hostname: #{hostname}"
-    puts "port: #{port || 25}"
-    puts "ssl_mode: #{ssl_mode}"
-    puts "username: #{username.inspect}"
+    puts "hostname: #{relay.hostname}"
+    puts "port: #{relay.port || 25}"
+    puts "ssl_mode: #{relay.ssl_mode}"
+    puts "username: #{relay.username.inspect}"
     puts "username decoded: #{relay.username ? CGI.unescape(relay.username) : nil}"
-    puts "password: #{password.nil? ? '****' : '****'}"
-    puts "authentication: #{authentication.inspect}"
+    puts "password: #{relay.password? ? '****' : ''}"
+    puts "authentication: #{relay.authentication.inspect}"
     puts "======================================="
 
     SMTPClient::Server.new(
-     relay.host,
+     relay.hostname,
      port: relay.port,
      ssl_mode: relay.ssl_mode,
      username: relay.username ? CGI.unescape(relay.username) : nil,

--- a/app/models/smtp_endpoint.rb
+++ b/app/models/smtp_endpoint.rb
@@ -48,25 +48,7 @@ class SMTPEndpoint < ApplicationRecord
   end
 
   def to_smtp_client_server
-    puts "=== SMTPEndpoint -> SMTPClient::Server ==="
-    puts "hostname: #{hostname}"
-    puts "port: #{port || 25}"
-    puts "ssl_mode: #{ssl_mode}"
-    puts "username: #{username.inspect}"
-    puts "username decoded: #{relay.username ? CGI.unescape(relay.username) : nil}"
-    puts "password: #{password.nil? ? '****' : '****'}"
-    puts "authentication: #{authentication.inspect}"
-    puts "======================================="
-
-    SMTPClient::Server.new(
-     relay.host,
-     port: relay.port,
-     ssl_mode: relay.ssl_mode,
-     username: relay.username ? CGI.unescape(relay.username) : nil,
-     password: relay.password ? CGI.unescape(relay.password) : nil,
-     authentication: relay.authentication ? relay.authentication : nil
-   )
-
+    SMTPClient::Server.new(hostname, port: port || 25, ssl_mode: ssl_mode)
   end
 
 end

--- a/app/models/smtp_endpoint.rb
+++ b/app/models/smtp_endpoint.rb
@@ -49,17 +49,17 @@ class SMTPEndpoint < ApplicationRecord
 
   def to_smtp_client_server
     puts "=== SMTPEndpoint -> SMTPClient::Server ==="
-    puts "hostname: #{relay.hostname}"
-    puts "port: #{relay.port || 25}"
-    puts "ssl_mode: #{relay.ssl_mode}"
-    puts "username: #{relay.username.inspect}"
+    puts "hostname: #{hostname}"
+    puts "port: #{port || 25}"
+    puts "ssl_mode: #{ssl_mode}"
+    puts "username: #{username.inspect}"
     puts "username decoded: #{relay.username ? CGI.unescape(relay.username) : nil}"
-    puts "password: #{relay.password? ? '****' : ''}"
-    puts "authentication: #{relay.authentication.inspect}"
+    puts "password: #{password.nil? ? '****' : '****'}"
+    puts "authentication: #{authentication.inspect}"
     puts "======================================="
 
     SMTPClient::Server.new(
-     relay.hostname,
+     relay.host,
      port: relay.port,
      ssl_mode: relay.ssl_mode,
      username: relay.username ? CGI.unescape(relay.username) : nil,

--- a/app/models/smtp_endpoint.rb
+++ b/app/models/smtp_endpoint.rb
@@ -48,7 +48,25 @@ class SMTPEndpoint < ApplicationRecord
   end
 
   def to_smtp_client_server
-    SMTPClient::Server.new(hostname, port: port || 25, ssl_mode: ssl_mode)
+    puts "=== SMTPEndpoint -> SMTPClient::Server ==="
+    puts "hostname: #{hostname}"
+    puts "port: #{port || 25}"
+    puts "ssl_mode: #{ssl_mode}"
+    puts "username: #{username.inspect}"
+    puts "username decoded: #{relay.username ? CGI.unescape(relay.username) : nil}"
+    puts "password: #{password.nil? ? '****' : '****'}"
+    puts "authentication: #{authentication.inspect}"
+    puts "======================================="
+
+    SMTPClient::Server.new(
+     relay.host,
+     port: relay.port,
+     ssl_mode: relay.ssl_mode,
+     username: relay.username ? CGI.unescape(relay.username) : nil,
+     password: relay.password ? CGI.unescape(relay.password) : nil,
+     authentication: relay.authentication ? relay.authentication : nil
+   )
+
   end
 
 end

--- a/app/senders/smtp_sender.rb
+++ b/app/senders/smtp_sender.rb
@@ -249,6 +249,16 @@ class SMTPSender < BaseSender
       relays = relays.filter_map do |relay|
         next unless relay.host.present?
 
+      puts "=== SMTPSender -> SMTPSender::smtp_relays ==="
+      puts "hostname: #{relay.host}"
+      puts "port: #{relay.port || 25}"
+      puts "ssl_mode: #{relay.ssl_mode}"
+      puts "username: #{relay.username.inspect}"
+      puts "username decoded: #{relay.username ? CGI.unescape(relay.username) : nil}"
+      puts "password: #{relay.password.nil? ? '****' : '****'}"
+      puts "authentication: #{relay.authentication.inspect}"
+      puts "======================================="
+        
       SMTPClient::Server.new(
         relay.host,
         port: relay.port,

--- a/app/senders/smtp_sender.rb
+++ b/app/senders/smtp_sender.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'cgi'
-
 class SMTPSender < BaseSender
 
   attr_reader :endpoints
@@ -249,24 +247,7 @@ class SMTPSender < BaseSender
       relays = relays.filter_map do |relay|
         next unless relay.host.present?
 
-      puts "=== SMTPSender -> SMTPSender::smtp_relays ==="
-      puts "hostname: #{relay.host}"
-      puts "port: #{relay.port || 25}"
-      puts "ssl_mode: #{relay.ssl_mode}"
-      puts "username: #{relay.username.inspect}"
-      puts "username decoded: #{relay.username ? CGI.unescape(relay.username) : nil}"
-      puts "password: #{relay.password.nil? ? '****' : '****'}"
-      puts "authentication: #{relay.authentication.inspect}"
-      puts "======================================="
-        
-      SMTPClient::Server.new(
-        relay.host,
-        port: relay.port,
-        ssl_mode: relay.ssl_mode,
-        username: relay.username ? CGI.unescape(relay.username) : nil,
-        password: relay.password ? CGI.unescape(relay.password) : nil,
-        authentication: relay.authentication ? relay.authentication : nil
-      )
+        SMTPClient::Server.new(relay.host, port: relay.port, ssl_mode: relay.ssl_mode)
       end
 
       @smtp_relays = relays.empty? ? nil : relays

--- a/app/senders/smtp_sender.rb
+++ b/app/senders/smtp_sender.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'cgi'
+
 class SMTPSender < BaseSender
 
   attr_reader :endpoints
@@ -247,7 +249,14 @@ class SMTPSender < BaseSender
       relays = relays.filter_map do |relay|
         next unless relay.host.present?
 
-        SMTPClient::Server.new(relay.host, port: relay.port, ssl_mode: relay.ssl_mode)
+      SMTPClient::Server.new(
+        relay.host,
+        port: relay.port,
+        ssl_mode: relay.ssl_mode,
+        username: relay.username ? CGI.unescape(relay.username) : nil,
+        password: relay.password ? CGI.unescape(relay.password) : nil,
+        authentication: relay.authentication ? relay.authentication : nil
+      )
       end
 
       @smtp_relays = relays.empty? ? nil : relays

--- a/lib/postal/config_schema.rb
+++ b/lib/postal/config_schema.rb
@@ -78,11 +78,26 @@ module Postal
         transform do |value|
           uri = URI.parse(value)
           query = uri.query ? CGI.parse(uri.query) : {}
-          {
+          result = {
             host: uri.host,
             port: uri.port || 25,
-            ssl_mode: query["ssl_mode"]&.first || "Auto"
+            ssl_mode: query["ssl_mode"]&.first || "Auto",
+            username: uri.user,
+            password: uri.password,
+            authentication: query["authentication"]&.first # ex: "login" ou "plain"
           }
+
+          # Debug
+          warn "=== SMTP Relay Parsed ==="
+          warn "host: #{result[:host]}"
+          warn "port: #{result[:port]}"
+          warn "ssl_mode: #{result[:ssl_mode]}"
+          warn "username: #{result[:username].inspect}"
+          warn "password: #{result[:password] ? '****' : nil}"
+          warn "authentication: #{result[:authentication].inspect}"
+          warn "========================="
+
+          result
         end
       end
 

--- a/lib/postal/config_schema.rb
+++ b/lib/postal/config_schema.rb
@@ -87,7 +87,7 @@ module Postal
             authentication: query["authentication"]&.first # ex: "login" ou "plain"
           }
 
-          # Debug
+          # Debug temporaire pour vérifier ce qui est lu
           warn "=== SMTP Relay Parsed ==="
           warn "host: #{result[:host]}"
           warn "port: #{result[:port]}"


### PR DESCRIPTION
User/password included in the URI to enable authenticated connection to SMTP relays. Authentication type also added.
The URI for smtp_relays is in the following format:
smtp://[user:password@]server[:port]?[starttls=[always|auto]]&[authentication=[plain|login]]
Special caracters in User and password must be encoded.