### PR TITLE
Switch to https://gem.coop/ from rubygems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-source "https://rubygems.org"
+source "https://gem.coop"
 gem "abbrev"
 gem "authie"
 gem "autoprefixer-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: https://rubygems.org/
+  remote: https://gem.coop
   specs:
     abbrev (0.1.2)
     actioncable (7.1.5.2)


### PR DESCRIPTION
See explanations of why on https://gem.coop/ and https://martinemde.com/2025/10/05/announcing-gem-coop.html