### PR TITLE
Remove raw messages when retention is disabled

### DIFF
--- a/app/lib/message_dequeuer/outgoing_message_processor.rb
+++ b/app/lib/message_dequeuer/outgoing_message_processor.rb
@@ -22,6 +22,7 @@ module MessageDequeuer
         remove_recipient_from_suppression_list_on_success
         log_sender_result
         finish_processing
+        cleanup_raw_message
       end
     rescue StandardError => e
       handle_exception(e)
@@ -184,6 +185,12 @@ module MessageDequeuer
 
       log "message processing complete"
       remove_from_queue
+    end
+
+    def cleanup_raw_message
+      return if queued_message.server.raw_message_retention_days.to_i > 0 && queued_message.server.raw_message_retention_size.to_i > 0
+      queued_message.message.delete_raw_message
+      log "raw message removed due to retention settings"
     end
 
   end

--- a/lib/postal/message_db/message.rb
+++ b/lib/postal/message_db/message.rb
@@ -289,6 +289,17 @@ module Postal
       end
 
       #
+      # Delete the raw message from the database
+      #
+      def delete_raw_message
+        return unless raw_table
+
+        @database.query("DELETE FROM `#{@database.database_name}`.`#{raw_table}` WHERE id IN (#{raw_headers_id}, #{raw_body_id})")
+        @database.query("UPDATE `#{@database.database_name}`.`raw_message_sizes` SET size = size - #{size} WHERE table_name = '#{raw_table}'")
+        update(raw_table: nil, raw_headers_id: nil, raw_body_id: nil, size: nil)
+      end
+
+      #
       # Is there a raw message?
       #
       def raw_message?


### PR DESCRIPTION
After a message is processed its raw content is immediately deleted from the server if `raw message retention days` or `raw message retention size` is set to 0. This prevents storing unnecessary message data and helps reduce storage usage.