### PR TITLE
fix(webhooks): add scheduled task to unlock stale webhook request locks

### DIFF
--- a/app/lib/worker/process.rb
+++ b/app/lib/worker/process.rb
@@ -42,6 +42,7 @@ module Worker
       PruneWebhookRequestsScheduledTask,
       SendNotificationsScheduledTask,
       TidyQueuedMessagesTask,
+      TidyWebhookRequestsTask,
     ].freeze
 
     # @param [Integer] thread_count The number of worker threads to run in this process

--- a/app/models/webhook_request.rb
+++ b/app/models/webhook_request.rb
@@ -36,6 +36,8 @@ class WebhookRequest < ApplicationRecord
 
   serialize :payload, type: Hash
 
+  scope :with_stale_lock, -> { where("locked_at IS NOT NULL AND locked_at < ?", 1.hour.ago) }
+
   class << self
 
     def trigger(server, event, payload = {})

--- a/app/scheduled_tasks/tidy_webhook_requests_task.rb
+++ b/app/scheduled_tasks/tidy_webhook_requests_task.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class TidyWebhookRequestsTask < ApplicationScheduledTask
+
+  def call
+    WebhookRequest.with_stale_lock.find_each do |request|
+      logger.info "unlocking stale webhook request #{request.id} (locked at #{request.locked_at} by #{request.locked_by})"
+      request.unlock
+    end
+  end
+
+  def self.next_run_after
+    quarter_to_each_hour
+  end
+
+end


### PR DESCRIPTION
## Summary

- **Problem:** When a worker process crashes or is killed (common in Kubernetes with rolling updates, OOM kills, pod evictions), locks held on `webhook_requests` rows are never released. Unlike `QueuedMessage` which has `TidyQueuedMessagesTask` to clean up stale locks, `WebhookRequest` had no equivalent cleanup mechanism — causing webhook delivery to be permanently blocked.
- **Fix:** Adds a `TidyWebhookRequestsTask` scheduled task (runs hourly) that finds webhook requests locked for more than 1 hour and unlocks them so they can be retried.
- Adds a `with_stale_lock` scope on `WebhookRequest` (mirrors the existing pattern on `QueuedMessage`)

## Changes

| File | Change |
|------|--------|
| `app/models/webhook_request.rb` | Added `with_stale_lock` scope (locks older than 1 hour) |
| `app/scheduled_tasks/tidy_webhook_requests_task.rb` | New scheduled task to unlock stale webhook requests |
| `app/lib/worker/process.rb` | Registered `TidyWebhookRequestsTask` in the worker TASKS array |

## Why unlock instead of destroy?

`TidyQueuedMessagesTask` **destroys** stale queued messages because they represent outbound email delivery attempts that are likely no longer relevant. Webhook requests, however, carry event notifications that downstream systems may still need — so we **unlock** them to allow retry rather than silently dropping them.

## Test plan

- [ ] Verify `WebhookRequest.with_stale_lock` returns only records with `locked_at` older than 1 hour
- [ ] Verify `TidyWebhookRequestsTask` unlocks stale records (sets `locked_by` and `locked_at` to nil)
- [ ] Verify previously-stuck webhook requests are picked up again by `ProcessWebhookRequestsJob` after unlock
- [ ] Confirm no impact on actively-locked (non-stale) webhook requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)