### PR TITLE
Add blank option to server IP-pool select; prompt for rule form

### DIFF
--- a/app/views/ip_pool_rules/_form.html.haml
+++ b/app/views/ip_pool_rules/_form.html.haml
@@ -24,7 +24,7 @@
       .fieldSet__field
         = f.label :ip_pool_id, "IP Pool", :class => 'fieldSet__label'
         .fieldSet__input
-          = f.collection_select :ip_pool_id, organization.ip_pools.includes(:ip_addresses).order("`default` desc, name asc"), :id, :name, {}, :class => 'input input--select'
+          = f.collection_select :ip_pool_id, organization.ip_pools.includes(:ip_addresses).order("`default` desc, name asc"), :id, :name, { prompt: "Select an IP pool" }, :class => 'input input--select'
           %p.fieldSet__text
             This is the IP pool that this message should be delivered from.
 

--- a/app/views/servers/_form.html.haml
+++ b/app/views/servers/_form.html.haml
@@ -25,7 +25,7 @@
       .fieldSet__field
         = f.label :ip_pool_id, :class => 'fieldSet__label'
         .fieldSet__input
-          = f.collection_select :ip_pool_id, organization.ip_pools.includes(:ip_addresses).order("`default` desc, name asc"), :id, :name, {}, :class => 'input input--select'
+          = f.collection_select :ip_pool_id, organization.ip_pools.includes(:ip_addresses).order("`default` desc, name asc"), :id, :name, { include_blank: "No specific pool (use rules / default)" }, :class => 'input input--select'
           %p.fieldSet__text
             This is the set of IP addresses which outbound e-mails will be delivered from.
 


### PR DESCRIPTION
## Summary

  The IP-pool `collection_select` on the server form (and rule form) had no blank option, so once a pool was assigned, there was no UI path to clear it. The model already accepts a nil `ip_pool_id` — only the view
  stood in the way.

  - Server form: adds `include_blank: "No specific pool (use rules / default)"` (server pool is optional).
  - Rule form: adds `prompt: "Select an IP pool"` (rule pool is required, so prompt is more appropriate than blank).

  ## Test plan

  - [x] Picking the blank option in the server form persists `servers.ip_pool_id = NULL`.
  - [x] After unset, new `QueuedMessage` rows have `ip_address_id = NULL`.
  - [x] Toggle works in both directions.
  - [x] Rule form shows the prompt for new rules; existing rules render unchanged.