### PR TITLE
(fix) prevent nil description errors in routes view

### DIFF
--- a/app/views/routes/index.html.haml
+++ b/app/views/routes/index.html.haml
@@ -40,7 +40,7 @@
             .routeList__details
               %p.routeList__endpoint{:class => "routeList__endpoint--#{route.endpoint_type&.underscore || 'none'}"}
                 - if route.mode == 'Endpoint'
-                  = route.endpoint.description
+                  = route.endpoint&.description || "Missing endpoint"
                 - else
                   = t("route_modes.#{route.mode.underscore}")
               %p.routeList__spamMode= t("route_spam_modes.#{route.spam_mode.underscore}")


### PR DESCRIPTION
Handling missing route endpoint
descriptions in routes/index.html.haml to avoid 500 errors when associated objects are nil or partially removed.

Fixes issue: https://github.com/postalserver/postal/issues/3567