### PR TITLE
Add priority subject bypass and configurable send limit retry interval

### DIFF
--- a/README.custom.md
+++ b/README.custom.md
@@ -1,0 +1,133 @@
+# Postal Custom — Priority Subjects & Configurable Send Limit Retry
+
+This is a custom build of [Postal](https://github.com/postalserver/postal) v3.3.6 with two additional features aimed at high-volume transactional email deployments.
+
+---
+
+## New Features
+
+### 1. Priority Subject Keywords
+
+**Problem:** When a mail server hits its hourly send limit, all outbound emails are held — including time-sensitive transactional emails like password resets and OTPs.
+
+**Solution:** Admins can configure a list of subject keywords. Any outgoing email whose subject contains one of these keywords will bypass the hourly send limit and be delivered immediately, regardless of current volume.
+
+**How it works:**
+- Keywords are matched case-insensitively and as substrings (e.g. keyword `reset` matches subject `Password Reset Request`)
+- Non-matching emails continue to follow the normal send limit behavior
+- Only server admins can manage keywords
+
+**Configuration (Admin UI):**
+1. Log in to Postal as an admin
+2. Go to **Mail Server → Settings → Advanced**
+3. Scroll to the **Priority Subject Keywords** section
+4. Use the **Add Keyword** form to add keywords one at a time
+5. Click **Remove** next to any keyword to delete it
+
+---
+
+### 2. Configurable Send Limit Retry Interval
+
+**Problem:** When the hourly send limit is reached, all queued messages are placed in a "Held" state and require manual intervention to release — even if the limit resets within an hour.
+
+**Solution:** Admins can set a retry interval (in minutes). When the send limit is exceeded, messages stay in the queue and are automatically retried after the configured interval instead of being held indefinitely.
+
+**How it works:**
+- If **Send Limit Retry Interval** is set (e.g. `60`): messages are re-queued with a `retry_after` timestamp set that many minutes in the future. When the limit resets, they are delivered automatically.
+- If left **blank**: original Postal behavior is preserved — messages are held until manually released.
+
+**Configuration (Admin UI):**
+1. Log in to Postal as an admin
+2. Go to **Mail Server → Settings → Advanced**
+3. Set the **Send Limit Retry Interval** field to the number of minutes between retries (e.g. `60` for hourly retry)
+4. Click **Save server**
+
+---
+
+## Installation
+
+### Prerequisites
+
+- Docker and Docker Compose
+- An existing Postal v3.3.6 installation, **or** a fresh install using the official Postal setup guide
+
+### Option A — Use the Pre-built Docker Image
+
+Replace the official image in your `docker-compose.yml`:
+
+```yaml
+# Before:
+image: ghcr.io/postalserver/postal:3.3.6
+
+# After:
+image: <your-dockerhub-username>/postal-custom:3.3.6
+```
+
+Then run migrations:
+
+```bash
+docker compose run --rm runner postal upgrade
+```
+
+### Option B — Build from Source
+
+```bash
+git clone https://github.com/<your-github-username>/postal-custom.git
+cd postal-custom
+docker build -t postal-custom:3.3.6 .
+```
+
+Update your `docker-compose.yml` to use `postal-custom:3.3.6`, then:
+
+```bash
+docker compose up -d
+docker compose run --rm runner postal upgrade
+```
+
+---
+
+## Database Migrations
+
+Two migrations are included:
+
+| Migration | Description |
+|---|---|
+| `20260514000000_add_priority_subjects_to_servers` | Adds `priority_subjects` (text) column to `servers` table |
+| `20260514000001_add_send_limit_retry_interval_to_servers` | Adds `send_limit_retry_interval` (integer, minutes) column to `servers` table |
+
+Run them with:
+
+```bash
+docker compose run --rm runner postal upgrade
+```
+
+---
+
+## Files Changed from Upstream
+
+| File | Change |
+|---|---|
+| `db/migrate/20260514000000_add_priority_subjects_to_servers.rb` | New migration |
+| `db/migrate/20260514000001_add_send_limit_retry_interval_to_servers.rb` | New migration |
+| `app/models/server.rb` | Added `priority_subject_keywords`, `priority_subject_bypass?` methods |
+| `app/lib/message_dequeuer/outgoing_message_processor.rb` | Modified `check_send_limits` to support both features |
+| `app/controllers/servers_controller.rb` | Added `add_priority_subject`, `remove_priority_subject` actions and permitted params |
+| `config/routes.rb` | Added `add_priority_subject` and `remove_priority_subject` member routes |
+| `app/views/servers/advanced.html.haml` | Added UI for both features in the Admin → Advanced settings page |
+
+---
+
+## Upgrading
+
+When a new upstream Postal version is released:
+
+1. Fetch upstream changes: `git fetch upstream && git merge upstream/main`
+2. Resolve any conflicts in the files listed above
+3. Rebuild: `docker build -t postal-custom:<new-version> .`
+4. Deploy and migrate
+
+---
+
+## License
+
+MIT — same as the upstream [Postal](https://github.com/postalserver/postal) project.

--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -4,7 +4,7 @@ class ServersController < ApplicationController
 
   include WithinOrganization
 
-  before_action :admin_required, only: [:advanced, :suspend, :unsuspend]
+  before_action :admin_required, only: [:advanced, :add_priority_subject, :remove_priority_subject, :suspend, :unsuspend]
   before_action { params[:id] && @server = organization.servers.present.find_by_permalink!(params[:id]) }
 
   def index
@@ -47,6 +47,7 @@ class ServersController < ApplicationController
     if current_user.admin?
       extra_params += [
         :send_limit,
+        :send_limit_retry_interval,
         :allow_sender,
         :privacy_mode,
         :log_smtp_data,
@@ -81,6 +82,24 @@ class ServersController < ApplicationController
   def queue
     @messages = @server.queued_messages.order(id: :desc).page(params[:page]).includes(:ip_address)
     @messages_with_message = @messages.include_message
+  end
+
+  def add_priority_subject
+    keyword = params[:keyword].to_s.strip
+    if keyword.present?
+      existing = (@server.priority_subjects || "").split("\n").map(&:strip).reject(&:blank?)
+      unless existing.include?(keyword)
+        @server.update!(priority_subjects: (existing + [keyword]).join("\n"))
+      end
+    end
+    redirect_to advanced_organization_server_path(organization, @server)
+  end
+
+  def remove_priority_subject
+    keyword = params[:keyword].to_s.strip
+    existing = (@server.priority_subjects || "").split("\n").map(&:strip).reject(&:blank?)
+    @server.update!(priority_subjects: existing.reject { |k| k == keyword }.join("\n"))
+    redirect_to advanced_organization_server_path(organization, @server)
   end
 
   def suspend

--- a/app/lib/message_dequeuer/outgoing_message_processor.rb
+++ b/app/lib/message_dequeuer/outgoing_message_processor.rb
@@ -117,12 +117,25 @@ module MessageDequeuer
 
     def check_send_limits
       if queued_message.server.send_limit_exceeded?
-        # If we're over the limit, we're going to be holding this message
-        log "server send limit has been exceeded, holding", send_limit: queued_message.server.send_limit
-        queued_message.server.update_columns(send_limit_exceeded_at: Time.now, send_limit_approaching_at: nil)
-        create_delivery "Held", details: "Message held because send limit (#{queued_message.server.send_limit}) has been reached."
-        remove_from_queue
-        stop_processing
+        subject = queued_message.message.headers["subject"]&.last.to_s
+        if queued_message.server.priority_subject_bypass?(subject)
+          log "send limit exceeded but subject matches priority keyword, bypassing limit", subject: subject
+          return
+        end
+
+        retry_interval = queued_message.server.send_limit_retry_interval
+        if retry_interval.present? && retry_interval > 0
+          log "send limit exceeded, will retry in #{retry_interval} minutes", send_limit: queued_message.server.send_limit
+          queued_message.server.update_columns(send_limit_exceeded_at: Time.now, send_limit_approaching_at: nil)
+          queued_message.retry_later(retry_interval.minutes)
+          stop_processing
+        else
+          log "server send limit has been exceeded, holding", send_limit: queued_message.server.send_limit
+          queued_message.server.update_columns(send_limit_exceeded_at: Time.now, send_limit_approaching_at: nil)
+          create_delivery "Held", details: "Message held because send limit (#{queued_message.server.send_limit}) has been reached."
+          remove_from_queue
+          stop_processing
+        end
       elsif queued_message.server.send_limit_approaching?
         # If we're approaching the limit, just say we are but continue to process the message
         queued_message.server.update_columns(send_limit_approaching_at: Time.now, send_limit_exceeded_at: nil)

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -203,6 +203,16 @@ class Server < ApplicationRecord
     send_volume >= send_limit
   end
 
+  def priority_subject_keywords
+    (priority_subjects || "").split("\n").map(&:strip).reject(&:blank?)
+  end
+
+  def priority_subject_bypass?(subject)
+    return false if priority_subjects.blank?
+
+    priority_subject_keywords.any? { |keyword| subject.to_s.downcase.include?(keyword.downcase) }
+  end
+
   def send_limit_warning(type)
     if organization.notification_addresses.present?
       AppMailer.send("server_send_limit_#{type}", self).deliver

--- a/app/views/servers/advanced.html.haml
+++ b/app/views/servers/advanced.html.haml
@@ -15,6 +15,12 @@
             = f.text_field :send_limit, :class => 'input input--text', :placeholder => "No limit"
             %p.fieldSet__text This is the maximum number of e-mails that can be sent through this mail server in a 60 minute period.
         .fieldSet__field
+          = f.label :send_limit_retry_interval, "Send Limit Retry Interval", :class => 'fieldSet__label'
+          .fieldSet__input
+            = f.text_field :send_limit_retry_interval, :class => 'input input--text', :placeholder => "e.g. 60 (minutes)"
+            %p.fieldSet__text
+              When the send limit is reached, queued messages will automatically retry after this many minutes instead of being held indefinitely. Leave blank to hold messages until manually released.
+        .fieldSet__field
           = f.label :allow_sender, "Allow sender header", :class => 'fieldSet__label'
           .fieldSet__input
             = f.select :allow_sender, [["No", false], ["Yes - can use Sender header", true]], {}, :class => 'input input--select'
@@ -60,6 +66,29 @@
 
       .fieldSetSubmit.fieldSetSubmit--wide.buttonSet
         = f.submit "Save server", :class => 'button button--positive js-form-submit'
+
+  .u-margin
+    %fieldset.fieldSet.fieldSet--wide
+      %legend.fieldSet__title Priority Subjects
+      .fieldSet__field
+        %p.fieldSet__label Priority Subject Keywords
+        .fieldSet__input
+          %p.fieldSet__text
+            Emails whose subject contains any of these keywords will bypass the hourly send limit and be delivered immediately.
+          - keywords = @server.priority_subject_keywords
+          - if keywords.any?
+            %ul.u-margin
+              - keywords.each do |keyword|
+                %li
+                  = keyword
+                  &nbsp;
+                  = link_to "Remove", remove_priority_subject_organization_server_path(organization, @server, keyword: keyword), method: :delete, class: "button button--small button--negative", data: { confirm: "Remove \"#{keyword}\"?" }
+          - else
+            %p.fieldSet__text No priority keywords configured yet.
+          %br
+          = form_tag add_priority_subject_organization_server_path(organization, @server), method: :post, style: "display:flex;gap:8px;align-items:center" do
+            = text_field_tag :keyword, "", placeholder: "e.g. Password Reset", class: "input input--text"
+            = submit_tag "Add Keyword", class: "button button--positive"
 
   - if @server.suspended_at
     = form_tag [:unsuspend, organization, @server], :remote => true do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,8 @@ Rails.application.routes.draw do
       get "help/outgoing" => "help#outgoing"
       get "help/incoming" => "help#incoming"
       get :advanced, on: :member
+      post :add_priority_subject, on: :member
+      delete :remove_priority_subject, on: :member
       post :suspend, on: :member
       post :unsuspend, on: :member
     end

--- a/db/migrate/20260514000000_add_priority_subjects_to_servers.rb
+++ b/db/migrate/20260514000000_add_priority_subjects_to_servers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPrioritySubjectsToServers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :servers, :priority_subjects, :text
+  end
+end

--- a/db/migrate/20260514000001_add_send_limit_retry_interval_to_servers.rb
+++ b/db/migrate/20260514000001_add_send_limit_retry_interval_to_servers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSendLimitRetryIntervalToServers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :servers, :send_limit_retry_interval, :integer
+  end
+end


### PR DESCRIPTION
## Summary

This PR adds two features to improve transactional email delivery in high-volume deployments:

### 1. Priority Subject Keywords

When a mail server hits its hourly send limit, all outbound emails are held — including time-sensitive emails like password resets and OTPs. This feature allows admins to configure subject keywords that bypass the send limit entirely.

- Keywords are matched case-insensitively as substrings
- Configured per mail server in **Admin → Settings → Advanced**
- Full CRUD UI: add individual keywords with an Add form, remove each with a Remove button
- Only accessible to server admins

**Files changed:**
- `db/migrate/20260514000000_add_priority_subjects_to_servers.rb` — new `priority_subjects` text column
- `app/models/server.rb` — `priority_subject_keywords` and `priority_subject_bypass?` methods
- `app/lib/message_dequeuer/outgoing_message_processor.rb` — bypass check in `check_send_limits`
- `app/controllers/servers_controller.rb` — `add_priority_subject` / `remove_priority_subject` actions
- `config/routes.rb` — two new admin-only member routes
- `app/views/servers/advanced.html.haml` — keyword list UI with add/remove

### 2. Configurable Send Limit Retry Interval

Currently, when the send limit is exceeded, messages are held indefinitely and require manual release. This feature allows admins to set a retry interval (in minutes) so messages are automatically re-queued and delivered once the limit resets.

- If interval is set: messages stay in queue with a `retry_after` timestamp
- If left blank: existing hold behavior is preserved (backward compatible)
- Configured in the same **Admin → Settings → Advanced** page

**Files changed:**
- `db/migrate/20260514000001_add_send_limit_retry_interval_to_servers.rb` — new `send_limit_retry_interval` integer column
- `app/models/server.rb` — column available via ActiveRecord
- `app/lib/message_dequeuer/outgoing_message_processor.rb` — retry path in `check_send_limits`
- `app/controllers/servers_controller.rb` — permitted param for admins
- `app/views/servers/advanced.html.haml` — number field in admin UI

## Test plan

- [ ] Set a send limit of 5 on a test server, send 6 emails — confirm 6th is held
- [ ] Add "Password Reset" as a priority keyword, send email with that subject past the limit — confirm it bypasses hold
- [ ] Set retry interval to 1 (minute), trigger send limit — confirm message retries automatically after 1 minute
- [ ] Leave retry interval blank — confirm original hold behavior is unchanged
- [ ] Verify add/remove keyword UI works correctly in Admin → Advanced settings
- [ ] Verify non-admins cannot access the keyword management routes

## Motivation

Deployments that send both bulk newsletters and transactional emails (OTP, password reset) need a way to ensure critical emails are never delayed by volume limits. These two features together provide a complete solution without requiring separate mail server infrastructure.