### PR TITLE
fix(smtp-server): encode subject to UTF-8 before database insertion

### DIFF
--- a/lib/postal/message_db/message.rb
+++ b/lib/postal/message_db/message.rb
@@ -88,7 +88,7 @@ module Postal
       def copy_attributes_from_raw_message
         return unless raw_message
 
-        self.subject = headers["subject"]&.last.to_s[0, 200]
+        self.subject = encode_utf8(headers["subject"]&.last.to_s)[0, 200]
         self.message_id = headers["message-id"]&.last
         return unless message_id
 
@@ -577,6 +577,25 @@ module Postal
       end
 
       private
+
+      def encode_utf8(str)
+        return "" if str.nil?
+
+        # If the string is already valid UTF-8, return it as-is
+        if str.encoding == Encoding::UTF_8 && str.valid_encoding?
+          return str
+        end
+
+        # Try to force UTF-8 interpretation
+        str.force_encoding("UTF-8")
+        return str if str.valid_encoding?
+
+        # If not valid UTF-8, assume ISO-8859-1 and convert
+        str.force_encoding("ISO-8859-1").encode("UTF-8")
+      rescue EncodingError
+        # Last resort: replace invalid characters
+        str.encode("UTF-8", invalid: :replace, undef: :replace, replace: "?")
+      end
 
       def _update
         @database.update("messages", @attributes.except(:id), where: { id: @attributes["id"] })


### PR DESCRIPTION
## Problem

Emails with subjects containing raw non-UTF-8 characters (e.g. ISO-8859-1 `\xE9` for "é") without RFC 2047 MIME encoding cause `Mysql2::Error: Incorrect string value` during insertion into the messages table. The email is silently dropped — never delivered to the endpoint.

This is an issue that has existed since at least 2021 (see #1636). In environments receiving mail from legacy systems (ERPs, invoicing software), this can affect hundreds of emails per day.

## Root cause

In `lib/postal/message_db/message.rb`, the subject is extracted via `headers["subject"]&.last.to_s[0, 200]` and inserted as-is. The `Mail` gem's `field.decoded` correctly handles RFC 2047 encoded headers (`=?ISO-8859-1?Q?...?=`), but when the sender does not encode the subject per RFC 2047 (raw ISO-8859-1 bytes), the string is passed through unchanged. MySQL in strict mode then rejects the invalid UTF-8.

## Fix

Added a private `encode_utf8` method that safely converts the subject to valid UTF-8:
1. No-op if already valid UTF-8
2. Re-interprets bytes as UTF-8 if possible
3. Falls back to ISO-8859-1 → UTF-8 conversion (most common case for European accented characters)
4. Last resort: replaces invalid characters with `?`

## Reproduction

```bash
# Send an email with raw ISO-8859-1 subject (\xE9 = é)
printf 'Subject: Facture/note de cr\xe9dit Nr 12345\r\n' | # via SMTP to Postal
```

Results in:
```
Mysql2::Error: Incorrect string value: '\xE9dit N...' for column \`postal-server-1\`.\`messages\`.\`subject\` at row 1
```

Closes #1636