### PR TITLE
fix(message-parser): match parts on mime_type so multipart/related survives tracking

### DIFF
--- a/lib/postal/message_parser.rb
+++ b/lib/postal/message_parser.rb
@@ -67,7 +67,11 @@ module Postal
 
     def parse_parts(parts)
       parts.each do |part|
-        case part.content_type
+        # Match on the bare MIME type rather than the full Content-Type header
+        # value: multipart/related containers commonly carry the RFC 2387
+        # type="text/html" parameter, which would otherwise match the
+        # /text\/html/ branch and destroy the container.
+        case part.mime_type
         when /text\/html/
           part.body = parse(part.body.decoded.dup, :html)
           part.content_transfer_encoding = nil

--- a/spec/lib/postal/message_parser_spec.rb
+++ b/spec/lib/postal/message_parser_spec.rb
@@ -22,4 +22,56 @@ describe Postal::MessageParser do
     expect(parser.new_body).to match(/^Hello world! https:\/\/click\.#{message.domain.name}/)
     expect(parser.tracked_links).to eq 1
   end
+
+  it "should not treat a multipart/related container with a type parameter as an HTML part" do
+    message = create_plain_text_message(server, "Hello world!", "test@example.com")
+    create(:track_domain, server: server, domain: message.domain)
+
+    raw = <<~MESSAGE.gsub("\n", "\r\n")
+      From: test@#{message.domain.name}
+      To: test@example.com
+      Subject: Inline image test
+      MIME-Version: 1.0
+      Content-Type: multipart/alternative;
+       boundary="alt-boundary"
+
+      --alt-boundary
+      Content-Type: text/plain; charset=utf-8
+
+      Hello world!
+      --alt-boundary
+      Content-Type: multipart/related;
+       boundary="rel-boundary";
+       type="text/html"
+
+      --rel-boundary
+      Content-Type: text/html; charset=utf-8
+
+      <html><body><p>Hello world!</p><img src="cid:img1"></body></html>
+      --rel-boundary
+      Content-Type: image/png; name=chart.png
+      Content-ID: <img1>
+      Content-Transfer-Encoding: base64
+      Content-Disposition: inline; filename=chart.png
+
+      iVBORw0KGgo=
+      --rel-boundary--
+
+      --alt-boundary--
+    MESSAGE
+    allow(message).to receive(:raw_message).and_return(raw)
+
+    parser = Postal::MessageParser.new(message)
+
+    parsed = Mail.new("#{parser.new_headers}\r\n\r\n#{parser.new_body}")
+    related = parsed.parts.detect { |p| p.mime_type == "multipart/related" }
+    expect(related).to_not be_nil
+    expect(related.parts.map(&:mime_type)).to match_array(["text/html", "image/png"])
+
+    html_part = related.parts.detect { |p| p.mime_type == "text/html" }
+    expect(html_part.body.decoded).to include("img/#{server.token}/#{message.token}")
+
+    image_part = related.parts.detect { |p| p.mime_type == "image/png" }
+    expect(image_part.content_id).to eq "<img1>"
+  end
 end


### PR DESCRIPTION
## Summary
MessageParser#parse_parts matches parts with case part.content_type, which returns the full Content-Type header value including parameters. A multipart/related container that carries the RFC 2387 type="text/html" parameter - which PHPMailer and other mainstream senders emit for HTML mails with inline CID images - therefore matches the first when /text\/html/ branch instead of the multipart branch.

The consequences for any tracked message with that structure (multipart/alternative containing multipart/related with inline images):
- the related container's raw source (child part headers, boundaries, base64 payloads) is decoded and reassigned as a text body,
- charset = UTF-8 is stamped onto the container header,
- on re-serialization the Mail gem rebuilds the container as multipart/alternative, with the raw source as a huge text part and the original children appended as siblings.

Since the images then live in an alternative container rather than a related one, no mail client resolves the cid: references anymore - the message arrives without inline images, and the tracking pixel never reaches the real HTML part either. We hit this in production sending via the send/raw API with open tracking enabled.

## Fix
Match on part.mime_type, the bare MIME type without parameters. This is consistent with generate(), which already inspects @mail.mime_type for non-multipart messages. No behavior change for any part whose Content-Type carries no parameters that collide with the matchers.

## Repro / validation
Standalone reproduction with the mail gem (structure of the re-serialized message after parse_parts):

Before (case part.content_type):
multipart/alternative > [text/plain, multipart/alternative > [text/plain (raw container source), text/html, image/png]] - related container destroyed, Content-ID lost, no pixel in HTML.

After (case part.mime_type):
multipart/alternative > [text/plain, multipart/related > [text/html (pixel injected), image/png with Content-ID]] - structure intact.

A regression spec is included: it feeds a multipart/alternative message with a nested multipart/related; type="text/html" container through the parser with a track domain enabled and asserts the related container, its image part's Content-ID and the injected tracking pixel in the HTML leaf all survive.