### PR TITLE
fix: send the SMTP greeting line and its CRLF in a single write

### DIFF
--- a/app/lib/smtp_server/server.rb
+++ b/app/lib/smtp_server/server.rb
@@ -129,7 +129,12 @@ module SMTPServer
                 end
                 # We know who the client is, welcome them.
                 client.logger&.debug "Client identified as #{client_ip_address}"
-                new_io.print("220 #{Postal::Config.postal.smtp_hostname} ESMTP Postal/#{client.trace_id}")
+                # Write the greeting line and its terminating CRLF in a single write. Using
+                # #print emits the string and the "$\" output record separator ("\r\n") as two
+                # separate writes, which can be sent as two TCP segments. Some clients read the
+                # greeting text before the CRLF arrives, issue EHLO early, and then mis-handle the
+                # stray CRLF prepended to the EHLO reply. Sending the line atomically avoids this.
+                new_io.write("220 #{Postal::Config.postal.smtp_hostname} ESMTP Postal/#{client.trace_id}\r\n")
               end
               # Register the client and its socket with nio4r
               monitor = @io_selector.register(new_io, :r)


### PR DESCRIPTION
## Summary

The initial `220` greeting is emitted with `IO#print`, which writes the greeting string and then the `$\` output record separator (`"\r\n"`, set in `prepare_environment`) as **two separate writes**. On the wire these can be flushed as two TCP segments: the greeting text, then a delayed CRLF.

## Impact

Strict clients that read the greeting text before its CRLF arrives may issue `EHLO` early; the trailing CRLF then arrives prepended to the `EHLO` reply and breaks their line parsing. Observed in production with **Persits AspEmail.NET**: the client keeps waiting for a "complete" greeting line, hangs until timeout, and never issues `STARTTLS`/`AUTH` — so no mail is ever sent.

TCP is a byte stream (RFC 5321 §2.1), so splitting a response across segments is legal server behaviour and such clients are arguably at fault. But every other response in the SMTP server is already written as a single line; making the greeting consistent (one atomic write, CRLF included) sidesteps the issue at zero cost.

## Change

`app/lib/smtp_server/server.rb`: replace `new_io.print("220 … ESMTP Postal/#{client.trace_id}")` (string + `$\`) with `new_io.write("220 … ESMTP Postal/#{client.trace_id}\r\n")`.

The bytes on the wire are identical (the previous `print` appended the same `"\r\n"` via `$\`); they are now guaranteed to be written together. No behaviour change for compliant clients, so existing specs are unaffected.