### PR TITLE
fix(smtp-server): treat TLS read disconnects as client-gone, not errors

### DIFF
--- a/app/lib/smtp_server/server.rb
+++ b/app/lib/smtp_server/server.rb
@@ -176,7 +176,11 @@ module SMTPServer
                   # Could not accept without blocking
                   # We will try again later
                   next
-                rescue OpenSSL::SSL::SSLError => e
+                rescue OpenSSL::SSL::SSLError, Errno::ECONNRESET, Errno::ETIMEDOUT => e
+                  # Client aborted the TLS handshake, e.g. by resetting the
+                  # connection mid SSL_accept (Errno::ECONNRESET) or letting it
+                  # time out. This is a routine client-gone event, not a server
+                  # error, so treat it the same as a failed negotiation.
                   client.logger&.debug "SSL Negotiation Failed: #{e.message}"
                   eof = true
                 end
@@ -190,8 +194,10 @@ module SMTPServer
                   if io.is_a?(OpenSSL::SSL::SSLSocket)
                     buffers[io] << io.readpartial(10_240) while io.pending.positive?
                   end
-                rescue EOFError, Errno::ECONNRESET, Errno::ETIMEDOUT
-                  # Client went away
+                rescue EOFError, Errno::ECONNRESET, Errno::ETIMEDOUT, OpenSSL::SSL::SSLError
+                  # Client went away. On a TLS socket an abrupt disconnect surfaces
+                  # as an OpenSSL::SSL::SSLError ("SSL_read: unexpected eof") rather
+                  # than an EOFError, so we treat it the same way.
                   eof = true
                 end
 
@@ -211,8 +217,11 @@ module SMTPServer
                     begin
                       io.write(iline.to_s + "\r\n")
                       io.flush
-                    rescue Errno::ECONNRESET
-                      # Client disconnected before we could write response
+                    rescue Errno::ECONNRESET, Errno::EPIPE
+                      # Client disconnected before we could write the response.
+                      # A closed peer surfaces as ECONNRESET or, when the socket
+                      # is already gone, as EPIPE ("broken pipe") - both mean the
+                      # client went away, not a server error.
                       eof = true
                     end
                   end


### PR DESCRIPTION
## Problem

When a client disconnects abruptly, OpenSSL and the socket layer raise errors that the SMTP server's event loop logged as genuine server errors — with a full backtrace and a Sentry report — despite being routine client-gone events (port scanners, load-balancer health checks, senders whose connection drops).

Three paths in `run_event_loop` were affected, each falling through to the generic `rescue StandardError`:

- **Handshake path** — a client resetting the connection mid `SSL_accept` raises `Errno::ECONNRESET` (not an `SSLError`), which the handshake rescue did not handle.
- **Read path** — an abrupt disconnect while reading on a TLS socket raises `OpenSSL::SSL::SSLError` (`SSL_read: unexpected eof while reading`) rather than an `EOFError`. The read rescue only handled `EOFError`, `Errno::ECONNRESET` and `Errno::ETIMEDOUT`, so these fell through.
- **Write path** — a client gone before the response is written raises `Errno::EPIPE` ("broken pipe") in addition to the already-handled `Errno::ECONNRESET`.

## Fix

Extend each rescue so an abrupt disconnect on any path is treated the same as a plain-socket EOF (`eof = true`) — the connection is closed quietly instead of being reported as a server error:

- Handshake rescue: add `Errno::ECONNRESET, Errno::ETIMEDOUT`
- Read rescue: add `OpenSSL::SSL::SSLError`
- Write rescue: add `Errno::EPIPE`

No behaviour change for successful connections.
