### PR TITLE
Make drop_table idempotent so concurrent retention runs don't crash (#3595)

### DIFF
--- a/lib/postal/message_db/provisioner.rb
+++ b/lib/postal/message_db/provisioner.rb
@@ -59,10 +59,12 @@ module Postal
       end
 
       #
-      # Drop a table
+      # Drop a table. Uses IF EXISTS so that two workers running retention
+      # concurrently do not crash when the second one tries to drop a table
+      # the first has already removed.
       #
       def drop_table(table_name)
-        @database.query("DROP TABLE `#{@database.database_name}`.`#{table_name}`")
+        @database.query("DROP TABLE IF EXISTS `#{@database.database_name}`.`#{table_name}`")
       end
 
       #

--- a/spec/lib/postal/message_db/database_spec.rb
+++ b/spec/lib/postal/message_db/database_spec.rb
@@ -73,5 +73,15 @@ describe Postal::MessageDB::Database do
         end.to raise_error(Mysql2::Error)
       end
     end
+
+    describe "#drop_table" do
+      # The retention task's lock can be stolen after a few minutes, so two
+      # workers may call drop_table for the same table. Dropping a table that
+      # has already been removed must not raise (regression for #3595).
+      it "does not raise when the table no longer exists" do
+        expect { database.provisioner.drop_table("raw-does-not-exist") }
+          .not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
## Problem

`ProcessMessageRetentionScheduledTask` crashes with `Mysql2::Error: Unknown table` when two workers run retention concurrently (#3595). The task's lock is stealable after a few minutes, so two workers can call `Provisioner#drop_table` for the same `raw-<date>` table; the second one runs a bare `DROP TABLE` on an already-dropped table and raises.

In `lib/postal/message_db/provisioner.rb`, `drop_table` was the one un-guarded destructive query. Its sibling `create_raw_table` already tolerates the same concurrent-run race with `rescue Mysql2::Error ... raise unless ... already exists`.

## Fix

Use `DROP TABLE IF EXISTS`, so dropping an already-removed table is a no-op instead of an error. This mirrors the concurrent-run tolerance `create_raw_table` has, but at the SQL level so it doesn't swallow any unrelated `Mysql2::Error`.

Adds a spec asserting `drop_table` does not raise when the table no longer exists (it fails on the old bare `DROP TABLE` and passes with `IF EXISTS`).

## Scope

This is the safe, idempotent guard for the crash itself. @willpower232 noted on the issue that the underlying lock-renewal behaviour (two workers holding the retention lock at once) may also be worth revisiting — that's a separate change, and `IF EXISTS` stops the crash regardless of whether the lock overlap is later tightened.

---
AI disclosure: prepared with AI assistance (Claude Code); the fix was traced against the code and syntax-checked with `ruby -c` before submitting. The message_db specs run against MySQL, so the added spec is exercised by CI.
