### PR TITLE
feat: add read-only organization user roles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.repository == 'postalserver/postal' && github.ref == 'refs/heads/main'
     outputs:
       release_created: ${{ steps.release-please.outputs.release_created }}
       tag_name: ${{ steps.release-please.outputs.tag_name }} # e.g. v1.0.0
@@ -20,6 +20,7 @@ jobs:
   build:
     name: CI Image Build
     runs-on: ubuntu-latest
+    if: github.repository == 'postalserver/postal'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -43,6 +44,7 @@ jobs:
     name: Test Suite
     runs-on: ubuntu-latest
     needs: build
+    if: github.repository == 'postalserver/postal'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -64,6 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     if: >-
+      github.repository == 'postalserver/postal' &&
       startsWith(github.ref, 'refs/heads/') &&
       startsWith(github.ref, 'refs/heads/release-please-') != true &&
       startsWith(github.ref, 'refs/heads/dependabot/') != true
@@ -112,7 +115,7 @@ jobs:
     name: Publish Image
     runs-on: ubuntu-latest
     needs: [build, test, release-please]
-    if: ${{ needs.release-please.outputs.release_created }}
+    if: github.repository == 'postalserver/postal' && needs.release-please.outputs.release_created
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3

--- a/.github/workflows/readonly-release.yml
+++ b/.github/workflows/readonly-release.yml
@@ -115,13 +115,30 @@ jobs:
       - uses: actions/checkout@v4
       - uses: softprops/action-gh-release@v2
         with:
-          generate_release_notes: true
+          name: Organization read-only roles (Postal 3.3.7 custom build)
+          generate_release_notes: false
           body: |
-            ## Postal read-only organization users
+            > **Not an official [postalserver/postal](https://github.com/postalserver/postal) release.** Custom build from `${{ github.repository }}` adding organization read-only user roles on Postal **3.3.7**.
 
-            Custom Postal **3.3.7** image with per-organization roles (`readonly`, `member`, `admin`).
+            ## Tag naming
 
-            ### Pull the image
+            | Tag | Meaning |
+            |-----|---------|
+            | Git tag `${{ github.ref_name }}` | Release identifier for this custom build |
+            | Image `${{ env.VERSION }}` | Docker tag `3.3.7-readonly` (Postal base + feature) |
+            | Image `${{ github.ref_name }}` | Same as Git tag |
+
+            Future releases will use clearer tags (e.g. `org-readonly-1.0.0`). The `-readonly` suffix here means **this feature build**, not that Postal is read-only.
+
+            ## Features
+
+            Per-organization roles: **readonly**, **member**, **admin**.
+
+            - Blocks write requests (POST/PATCH/PUT/DELETE) for read-only org members
+            - Role selector in user admin UI
+            - Database migration: `organization_users.read_only`
+
+            ## Pull
 
             ```bash
             docker pull ${{ env.IMAGE }}:${{ github.ref_name }}
@@ -129,9 +146,9 @@ jobs:
             docker pull ${{ env.IMAGE }}:latest
             ```
 
-            ### Upgrade notes
+            ## Upgrade
 
-            Update all services in `docker-compose.yml` to the same tag, then:
+            Set the same image on all Postal services in compose, then:
 
             ```bash
             sudo postal stop
@@ -140,6 +157,6 @@ jobs:
             sudo postal start
             ```
 
-            Do **not** run host-level `postal upgrade` on custom images — it reverts compose to the upstream `ghcr.io/postalserver/postal` image.
+            Do **not** run host-level `postal upgrade` — it reverts compose to upstream `ghcr.io/postalserver/postal`.
 
             Upstream PR: https://github.com/postalserver/postal/pull/3622

--- a/.github/workflows/readonly-release.yml
+++ b/.github/workflows/readonly-release.yml
@@ -1,0 +1,143 @@
+---
+name: Readonly Postal Release
+
+on:
+  push:
+    branches:
+      - feature/organization-readonly-users
+      - main
+    tags:
+      - "v*-readonly"
+      - "readonly-*"
+  workflow_dispatch:
+    inputs:
+      version_tag:
+        description: "Image version tag (e.g. 3.3.7-readonly)"
+        required: false
+        default: "3.3.7-readonly"
+
+permissions:
+  contents: write
+  packages: write
+
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/postal-readonly
+  VERSION: 3.3.7-readonly
+
+jobs:
+  test:
+    name: Test Suite
+    if: github.repository_owner != 'postalserver'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          load: true
+          tags: postal-readonly:ci
+          target: ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Run specs
+        run: docker compose run --rm postal bundle exec rspec spec/models/organization_user_spec.rb spec/requests/readonly_organization_access_spec.rb
+        env:
+          POSTAL_IMAGE: postal-readonly:ci
+
+  build-and-push:
+    name: Build and Push Image
+    if: github.repository_owner != 'postalserver'
+    needs: test
+    runs-on: ubuntu-latest
+    outputs:
+      image_tags: ${{ steps.meta.outputs.tags }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker meta
+        id: meta
+        run: |
+          TAGS="${{ env.IMAGE }}:${{ env.VERSION }}"
+          TAGS="${TAGS},${{ env.IMAGE }}:latest"
+          TAGS="${TAGS},${{ env.IMAGE }}:sha-${GITHUB_SHA:0:7}"
+
+          if [[ "${GITHUB_REF}" == refs/heads/* ]]; then
+            BRANCH="${GITHUB_REF#refs/heads/}"
+            SLUG="$(echo "${BRANCH}" | tr '[:upper:]' '[:lower:]' | tr '/._' '-')"
+            TAGS="${TAGS},${{ env.IMAGE }}:branch-${SLUG}"
+          fi
+
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            GIT_TAG="${GITHUB_REF#refs/tags/}"
+            TAGS="${TAGS},${{ env.IMAGE }}:${GIT_TAG}"
+          fi
+
+          if [ -n "${{ github.event.inputs.version_tag }}" ]; then
+            TAGS="${TAGS},${{ env.IMAGE }}:${{ github.event.inputs.version_tag }}"
+          fi
+
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          target: full
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            VERSION=${{ env.VERSION }}
+            BRANCH=${{ github.ref_name }}
+
+  release:
+    name: GitHub Release
+    if: github.repository_owner != 'postalserver' && startsWith(github.ref, 'refs/tags/')
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          body: |
+            ## Postal read-only organization users
+
+            Custom Postal **3.3.7** image with per-organization roles (`readonly`, `member`, `admin`).
+
+            ### Pull the image
+
+            ```bash
+            docker pull ${{ env.IMAGE }}:${{ github.ref_name }}
+            docker pull ${{ env.IMAGE }}:${{ env.VERSION }}
+            docker pull ${{ env.IMAGE }}:latest
+            ```
+
+            ### Upgrade notes
+
+            Update all services in `docker-compose.yml` to the same tag, then:
+
+            ```bash
+            sudo postal stop
+            sudo docker compose -f /opt/postal/install/docker-compose.yml pull
+            sudo docker compose -f /opt/postal/install/docker-compose.yml --profile tools run --rm runner postal upgrade
+            sudo postal start
+            ```
+
+            Do **not** run host-level `postal upgrade` on custom images — it reverts compose to the upstream `ghcr.io/postalserver/postal` image.
+
+            Upstream PR: https://github.com/postalserver/postal/pull/3622

--- a/.github/workflows/readonly-release.yml
+++ b/.github/workflows/readonly-release.yml
@@ -43,9 +43,11 @@ jobs:
           push: false
           load: true
           tags: postal-readonly:ci
-          target: ci
+          target: full
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            VERSION=${{ env.VERSION }}
       - name: Run specs
         run: docker compose run --rm postal bundle exec rspec spec/models/organization_user_spec.rb spec/requests/readonly_organization_access_spec.rb
         env:

--- a/app/assets/stylesheets/application/components/_readonly_access.scss
+++ b/app/assets/stylesheets/application/components/_readonly_access.scss
@@ -1,0 +1,28 @@
+.is-readonly-org {
+  .noData__button,
+  .sidebar__new,
+  .domainList__delete,
+  .fieldSetSubmit,
+  .dangerZone,
+  .pageContent > p.u-center,
+  .pageContent .buttonSet--center,
+  .write-action {
+    display: none !important;
+  }
+
+  .navBar__item--write-action {
+    display: none;
+  }
+}
+
+.siteHeader__readonlyBadge {
+  margin-left: 12px;
+  padding: 2px 8px;
+  border-radius: 3px;
+  background: rgba(255, 255, 255, 0.18);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -61,6 +61,15 @@ class ApplicationController < ActionController::Base
     payload[:user] = logged_in? ? current_user.id : nil
   end
 
+  def organization_readonly?
+    false
+  end
+
+  def organization_write_access?
+    true
+  end
+  helper_method :organization_readonly?, :organization_write_access?
+
   def url_with_return_to(url)
     return_to = params[:return_to]
     if return_to.blank? ||

--- a/app/controllers/concerns/organization_authorization.rb
+++ b/app/controllers/concerns/organization_authorization.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module OrganizationAuthorization
+
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :require_organization_write_access
+    helper_method :organization_write_access?, :organization_readonly?
+  end
+
+  private
+
+  def organization_membership
+    return unless organization
+
+    @organization_membership ||= organization.user_assignment(current_user)
+  end
+
+  def organization_write_access?
+    return true if current_user.admin?
+    return false unless organization
+
+    organization_membership&.can_write?
+  end
+
+  def organization_readonly?
+    return false if current_user.admin?
+    return false unless organization
+
+    organization_membership&.read_only?
+  end
+
+  def organization_write_request?
+    !request.get? && !request.head?
+  end
+
+  def require_organization_write_access
+    return unless organization_write_request?
+    return unless organization
+    return if organization_write_access?
+
+    deny_organization_write_access
+  end
+
+  def require_organization_admin
+    return if current_user.admin?
+    return if organization.owner == current_user
+    return if organization_membership&.org_admin?
+
+    redirect_to organization_root_path(organization), alert: "You do not have permission to manage this organization."
+  end
+
+  def deny_organization_write_access
+    respond_to do |wants|
+      wants.html do
+        redirect_back fallback_location: organization_root_path(organization),
+                      alert: "You have read-only access to this organization and cannot make changes."
+      end
+      wants.json do
+        render json: { error: "Read-only access" }, status: :forbidden
+      end
+    end
+  end
+
+end

--- a/app/controllers/concerns/within_organization.rb
+++ b/app/controllers/concerns/within_organization.rb
@@ -3,6 +3,7 @@
 module WithinOrganization
 
   extend ActiveSupport::Concern
+  include OrganizationAuthorization
 
   included do
     helper_method :organization

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -2,7 +2,10 @@
 
 class OrganizationsController < ApplicationController
 
+  include OrganizationAuthorization
+
   before_action :admin_required, only: [:new, :create, :delete, :destroy]
+  before_action :require_organization_admin, only: [:update]
 
   def index
     if current_user.admin?
@@ -63,6 +66,6 @@ class OrganizationsController < ApplicationController
 
     @organization ||= params[:org_permalink] ? current_user.organizations_scope.find_by_permalink!(params[:org_permalink]) : nil
   end
-  helper_method :organization
+  helper_method :organization, :organization_readonly?
 
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,7 +17,7 @@ class UsersController < ApplicationController
   end
 
   def create
-    @user = User.new(params.require(:user).permit(:email_address, :first_name, :last_name, :password, :password_confirmation, :admin, organization_ids: []))
+    @user = User.new(params.require(:user).permit(:email_address, :first_name, :last_name, :password, :password_confirmation, :admin, organization_ids: [], organization_role_assignments: {}))
     if @user.save
       redirect_to_with_json :users, notice: "#{@user.name} has been created successfully."
     else
@@ -26,7 +26,7 @@ class UsersController < ApplicationController
   end
 
   def update
-    @user.attributes = params.require(:user).permit(:email_address, :first_name, :last_name, :admin, organization_ids: [])
+    @user.attributes = params.require(:user).permit(:email_address, :first_name, :last_name, :admin, organization_ids: [], organization_role_assignments: {})
 
     if @user == current_user && !@user.admin?
       respond_to do |wants|

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -77,7 +77,7 @@ class Organization < ApplicationRecord
   end
 
   def make_owner(new_owner)
-    user_assignment(new_owner).update(admin: true, all_servers: true)
+    user_assignment(new_owner).update(admin: true, all_servers: true, read_only: false)
     update(owner: new_owner)
   end
 

--- a/app/models/organization_user.rb
+++ b/app/models/organization_user.rb
@@ -10,12 +10,40 @@
 #  created_at      :datetime
 #  admin           :boolean          default(FALSE)
 #  all_servers     :boolean          default(TRUE)
+#  read_only       :boolean          default(FALSE), not null
 #  user_type       :string(255)
 #
 
 class OrganizationUser < ApplicationRecord
 
+  ROLES = %w[readonly member admin].freeze
+
   belongs_to :organization
   belongs_to :user, polymorphic: true, optional: true
+
+  def role
+    return "admin" if admin?
+
+    read_only? ? "readonly" : "member"
+  end
+
+  def org_admin?
+    admin?
+  end
+
+  def can_write?
+    !read_only?
+  end
+
+  def apply_role!(role_name)
+    case role_name.to_s
+    when "admin"
+      update!(admin: true, read_only: false)
+    when "readonly"
+      update!(admin: false, read_only: true)
+    else
+      update!(admin: false, read_only: false)
+    end
+  end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,6 +41,22 @@ class User < ApplicationRecord
   has_many :organization_users, dependent: :destroy, as: :user
   has_many :organizations, through: :organization_users
 
+  after_save :apply_organization_role_assignments, if: -> { @organization_role_assignments.present? }
+
+  def organization_role_assignments=(assignments)
+    @organization_role_assignments = assignments.to_h
+  end
+
+  def organization_membership(organization)
+    organization.user_assignment(self)
+  end
+
+  def can_write_to_organization?(organization)
+    return true if admin?
+
+    organization_membership(organization)&.can_write?
+  end
+
   def organizations_scope
     if admin?
       @organizations_scope ||= Organization.present
@@ -132,6 +148,18 @@ class User < ApplicationRecord
       user
     end
 
+  end
+
+  private
+
+  def apply_organization_role_assignments
+    @organization_role_assignments.each do |organization_id, role|
+      next if organization_id.blank?
+
+      membership = organization_users.find_by(organization_id: organization_id)
+      membership&.apply_role!(role.presence || "member")
+    end
+    @organization_role_assignments = nil
   end
 
 end

--- a/app/views/domains/index.html.haml
+++ b/app/views/domains/index.html.haml
@@ -20,10 +20,13 @@
   - if @domains.empty?
     .noData.noData--clean
       %h2.noData__title There are no domains for this server.
-      %p.noData__text
-        To send & receive messages you need to add & verify the domain you wish to send/receive
-        messages to/from. Add your domain below to get started.
-      %p.noData__button= link_to "Add your first domain", [:new, organization, @server, :domain], :class => "button button--positive"
+      - if organization_write_access?
+        %p.noData__text
+          To send & receive messages you need to add & verify the domain you wish to send/receive
+          messages to/from. Add your domain below to get started.
+        %p.noData__button= link_to "Add your first domain", [:new, organization, @server, :domain], :class => "button button--positive write-action"
+      - else
+        %p.noData__text No domains have been configured for this server.
 
   - else
     %ul.domainList.u-margin
@@ -69,6 +72,8 @@
             %li.domainList__links
               - if domain.verified?
                 = link_to "DNS setup", [:setup, organization, @server, domain]
-              = link_to "Delete", [organization, @server, domain], :remote => :delete, :method => :delete, :data => {:confirm => "Are you sure you wish to remove this domain?", :disable_with => "Deleting..."}, :class => 'domainList__delete'
+              - if organization_write_access?
+                = link_to "Delete", [organization, @server, domain], :remote => :delete, :method => :delete, :data => {:confirm => "Are you sure you wish to remove this domain?", :disable_with => "Deleting..."}, :class => 'domainList__delete write-action'
 
-    %p.u-center= link_to "Add new domain", [:new, organization, @server, :domain], :class => "button button--positive"
+    - if organization_write_access?
+      %p.u-center= link_to "Add new domain", [:new, organization, @server, :domain], :class => "button button--positive write-action"

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -8,7 +8,7 @@
     %link{:href => asset_path('favicon.png'), :rel => 'shortcut icon'}
     <meta name="turbolinks-cache-control" content="no-cache">
     = yield :head
-  %body
+  %body{class: (organization_readonly? ? 'is-readonly-org' : nil)}
     = display_flash
     %header.siteHeader{'data-turbolinks-permanent' => true}
       - if flash[:remember_login] && !auth_session.persistent?
@@ -23,6 +23,8 @@
       .siteHeader__inside
         .siteHeader__logo= link_to "Postal", root_path
         %p.siteHeader__version The open source e-mail platform
+        - if defined?(organization) && organization && organization_readonly?
+          %span.siteHeader__readonlyBadge Read-only
         %ul.siteHeader__nav
           - if defined?(organization) && organization
             %li.siteHeader__navItem

--- a/app/views/messages/_header.html.haml
+++ b/app/views/messages/_header.html.haml
@@ -4,5 +4,6 @@
     %li.navBar__item= link_to "Incoming Messages", [:incoming, organization, @server, :messages], :class => ['navBar__link', active_nav == :incoming ? 'is-active' : '']
     %li.navBar__item= link_to "Queue", [:queue, organization, @server], :class => ['navBar__link', active_nav == :queue ? 'is-active' : '']
     %li.navBar__item= link_to "Held", [:held, organization, @server, :messages], :class => ['navBar__link', active_nav == :held ? 'is-active' : '']
-    %li.navBar__item= link_to "Send Message", [:new, organization, @server, :message], :class => ['navBar__link', active_nav == :new ? 'is-active' : '']
     %li.navBar__item= link_to "Suppressions", [:suppressions, organization, @server, :messages], :class => ['navBar__link', active_nav == :suppressions ? 'is-active' : '']
+    - if organization_write_access?
+      %li.navBar__item.navBar__item--write-action= link_to "Send Message", [:new, organization, @server, :message], :class => ['navBar__link', active_nav == :new ? 'is-active' : '']

--- a/app/views/servers/_sidebar.html.haml
+++ b/app/views/servers/_sidebar.html.haml
@@ -13,4 +13,5 @@
             %p.sidebarServerList__mode.label{:class => "label--serverStatus-#{server.status.underscore}"}= t("server_statuses.#{server.status.underscore}")
             %p.sidebarServerList__title= server.name
             %p.sidebarServerList__quantity #{number_with_precision server.message_rate, :precision => 2} messages/minute
-      %p.sidebar__new= link_to "Build a new mail server", [:new, organization, :server]
+      - if organization_write_access?
+        %p.sidebar__new= link_to "Build a new mail server", [:new, organization, :server], :class => 'write-action'

--- a/app/views/servers/index.html.haml
+++ b/app/views/servers/index.html.haml
@@ -11,11 +11,14 @@
   - if @servers.empty?
     .noData.noData--clean
       %p.noData__title There are no mail servers for this organization yet.
-      %p.noData__text
-        Great - you've got an organization, now you need to provision a mail server.
-        Once you've got a mail server, you can start sending & receiving messages.
-      %p.noData__button.buttonSet.buttonSet--center
-        = link_to "Build your first mail server", [:new, organization, :server], :class => 'button button--positive'
+      - if organization_write_access?
+        %p.noData__text
+          Great - you've got an organization, now you need to provision a mail server.
+          Once you've got a mail server, you can start sending & receiving messages.
+        %p.noData__button.buttonSet.buttonSet--center
+          = link_to "Build your first mail server", [:new, organization, :server], :class => 'button button--positive write-action'
+      - else
+        %p.noData__text No mail servers are available in this organization.
   - else
     .js-searchable
       %p.messageSearch= text_field_tag 'query', params[:query], :class => 'messageSearch__input js-searchable__input js-focus-on-s', :placeholder => "Find a server..."
@@ -32,4 +35,5 @@
           %p.noData__title No servers were found...
           %p.noData__text
             There were no servers found matching what you've typed it.
-    %p.u-center= link_to "Build a new mail server", [:new, organization, :server], :class => 'button button--positive'
+    - if organization_write_access?
+      %p.u-center= link_to "Build a new mail server", [:new, organization, :server], :class => 'button button--positive write-action'

--- a/app/views/users/_form.html.haml
+++ b/app/views/users/_form.html.haml
@@ -39,7 +39,7 @@
       What level of access do you wish to grant?
     .fieldSet__titleSubText
       Admin users have full access to all organizations and settings. Non-admin users will only
-      have access to the organizations that you select here.
+      have access to the organizations that you select here. Choose a role for each organization.
     .fieldSet__field
       .fieldSet__label Admin?
       .fieldSet__input
@@ -47,10 +47,13 @@
         = f.select :admin, [["Yes - grant admin access", true], ["No - do not grant admin access", false]], {},:class => 'input input--select fieldSet__checkboxListAfter js-checkbox-list-toggle'
         %ul.checkboxList{:class => [@user.admin? ? 'is-hidden' : '']}
           - for org in Organization.order(:name).to_a
+            - membership = @user.organization_users.find { |ou| ou.organization_id == org.id }
+            - current_role = membership&.role || "member"
             %li.checkboxList__item
               .checkboxList__checkbox= check_box_tag "user[organization_ids][]", org.id, @user.organizations.include?(org), :id => "org_#{org.id}"
               .checkboxList__label
                 = label_tag "org_#{org.id}", org.name, :class => 'checkboxList__actualLabel'
+                = select_tag "user[organization_role_assignments][#{org.id}]", options_for_select([["Read only", "readonly"], ["Member", "member"], ["Organization admin", "admin"]], current_role), :class => 'input input--select', :style => 'margin-top: 8px;'
 
   .fieldSetSubmit.buttonSet
     = submit_tag @user.new_record? ? "Add User" : "Save User", :class => 'button button--positive js-form-submit'

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -19,6 +19,10 @@
                 %span.userList__tag.label.label--orange Pending
               
           %p.userList__email= user.email_address
+          - unless user.admin?
+            %p.userList__roles
+              - user.organization_users.includes(:organization).each do |membership|
+                %span.userList__tag.label.label--neutral= "#{membership.organization.name}: #{membership.role}"
         %ul.userList__actions
           %li= link_to "Edit user", [:edit, user]
           %li= link_to "Delete user", user, :method => :delete, :data => {:confirm => "Are you sure you wish to revoke #{user.name}'s access?", :disable_with => "Deleting..."}, :remote => true, :class => 'userList__revoke'

--- a/db/migrate/20260820120000_add_readonly_to_organization_users.rb
+++ b/db/migrate/20260820120000_add_readonly_to_organization_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddReadonlyToOrganizationUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :organization_users, :read_only, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_11_205229) do
+ActiveRecord::Schema[7.0].define(version: 2026_08_20_120000) do
   create_table "additional_route_endpoints", id: :integer, charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.integer "route_id"
     t.string "endpoint_type"
@@ -163,6 +163,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_11_205229) do
     t.datetime "created_at"
     t.boolean "admin", default: false
     t.boolean "all_servers", default: true
+    t.boolean "read_only", default: false, null: false
     t.string "user_type"
   end
 

--- a/spec/factories/organization_user_factory.rb
+++ b/spec/factories/organization_user_factory.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :organization_user do
+    organization
+    user factory: :user
+    admin { false }
+    read_only { false }
+    all_servers { true }
+  end
+end

--- a/spec/models/organization_user_spec.rb
+++ b/spec/models/organization_user_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe OrganizationUser do
+  subject(:membership) { build(:organization_user) }
+
+  describe "#role" do
+    it "returns admin when admin is true" do
+      membership.admin = true
+      expect(membership.role).to eq("admin")
+    end
+
+    it "returns readonly when read_only is true" do
+      membership.read_only = true
+      expect(membership.role).to eq("readonly")
+    end
+
+    it "returns member by default" do
+      expect(membership.role).to eq("member")
+    end
+  end
+
+  describe "#apply_role!" do
+    before { membership.save! }
+
+    it "sets readonly access" do
+      membership.apply_role!("readonly")
+      expect(membership.reload).to have_attributes(admin: false, read_only: true)
+    end
+
+    it "sets organization admin access" do
+      membership.apply_role!("admin")
+      expect(membership.reload).to have_attributes(admin: true, read_only: false)
+    end
+
+    it "sets member access" do
+      membership.update!(admin: true, read_only: true)
+      membership.apply_role!("member")
+      expect(membership.reload).to have_attributes(admin: false, read_only: false)
+    end
+  end
+
+  describe "#can_write?" do
+    it "is false for readonly users" do
+      membership.read_only = true
+      expect(membership.can_write?).to be false
+    end
+
+    it "is true for members" do
+      expect(membership.can_write?).to be true
+    end
+  end
+end

--- a/spec/requests/readonly_organization_access_spec.rb
+++ b/spec/requests/readonly_organization_access_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Read-only organization access", type: :request do
+  let(:admin) { create(:user, admin: true) }
+  let(:organization) { create(:organization, owner: admin) }
+  let(:readonly_user) { create(:user, email_address: "readonly@example.com") }
+  let(:server) { create(:server, organization: organization) }
+
+  before do
+    create(:organization_user, organization: organization, user: readonly_user, read_only: true)
+    post "/login", params: { email_address: readonly_user.email_address, password: "passw0rd" }
+  end
+
+  describe "GET requests" do
+    it "allows viewing the organization servers" do
+      get "/org/#{organization.permalink}/servers/#{server.permalink}"
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "write requests" do
+    it "blocks creating a credential" do
+      post "/org/#{organization.permalink}/servers/#{server.permalink}/credentials",
+           params: { credential: { type: "API", name: "Test", hold: false } }
+
+      expect(response).to have_http_status(:found)
+      follow_redirect!
+      expect(response.body).to include("read-only access")
+    end
+
+    it "blocks updating organization settings" do
+      patch "/org/#{organization.permalink}/settings",
+            params: { organization: { name: "Renamed Org" } }
+
+      expect(response).to have_http_status(:found)
+      follow_redirect!
+      expect(response.body).to match(/read-only access|do not have permission/i)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds per-organization user roles so teams can grant view-only access without full write permissions.

- **readonly** — can browse org resources; POST/PATCH/PUT/DELETE are blocked
- **member** — existing default write access within the organization
- **admin** — uses the existing `organization_users.admin` flag for org-level management

This builds on dormant schema fields already present on `organization_users` and adds a `read_only` boolean column.

## Motivation

Postal currently distinguishes global admins from organization members, but org members effectively have full write access. Several environments need auditors, support staff, or clients to view configuration and message metadata without changing settings.

This aligns with prior maintainer feedback on access control features being implemented per user rather than via global config (see #2287).

## Implementation

- `OrganizationAuthorization` concern blocks non-GET requests for read-only org members
- Included via `WithinOrganization` across org-scoped controllers
- User admin UI exposes a per-organization role dropdown
- UI hides common write actions when the current user is read-only
- Request and model specs included

## Test plan

- [x] `bundle exec rspec spec/models/organization_user_spec.rb spec/requests/readonly_organization_access_spec.rb`
- [x] Log in as a read-only org user and confirm browsing works
- [x] Confirm create/update/delete actions are blocked with a clear message
- [x] Confirm global admins and org admins retain write access
- [x] Run `postal upgrade` / `db:migrate` on an existing installation

## Notes

Happy to adjust naming, expand UI coverage, or discuss how this relates to other dormant `organization_users` fields (`all_servers`, `user_type`) before merge.