### PR TITLE
fix: use IP pools for routed address endpoints

### DIFF
--- a/app/lib/message_dequeuer/incoming_message_processor.rb
+++ b/app/lib/message_dequeuer/incoming_message_processor.rb
@@ -167,7 +167,7 @@ module MessageDequeuer
       when HTTPEndpoint
         sender = @state.sender_for(HTTPSender, queued_message.message.endpoint)
       when AddressEndpoint
-        sender = @state.sender_for(SMTPSender, queued_message.message.endpoint.domain, nil, rcpt_to: queued_message.message.endpoint.address)
+        sender = @state.sender_for(SMTPSender, queued_message.message.endpoint.domain, queued_message.ip_address, rcpt_to: queued_message.message.endpoint.address)
       else
         log "invalid endpoint for route (#{queued_message.message.endpoint_type})"
         create_delivery "HardFail", details: "Invalid endpoint for route."

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -283,7 +283,7 @@ class Server < ApplicationRecord
   end
 
   def ip_pool_for_message(message)
-    return unless message.scope == "outgoing"
+    return unless message.scope == "outgoing" || message.endpoint.is_a?(AddressEndpoint)
 
     [self, organization].each do |scope|
       rules = scope.ip_pool_rules.order(created_at: :desc)

--- a/spec/lib/message_dequeuer/incoming_message_processor_spec.rb
+++ b/spec/lib/message_dequeuer/incoming_message_processor_spec.rb
@@ -430,11 +430,13 @@ module MessageDequeuer
     context "when the route's endpoint is an Address endpoint" do
       let(:endpoint) { create(:address_endpoint, server: server) }
       let(:route) { create(:route, server: server, mode: "Endpoint", endpoint: endpoint) }
+      let(:ip_address) { create(:ip_address) }
+      let(:queued_message) { create(:queued_message, :locked, message: message, ip_address: ip_address) }
 
       it "gets a sender from the state and sends the message to it" do
         smtp_sender_double = double("SMTPSender")
         expect(smtp_sender_double).to receive(:send_message).with(queued_message.message).and_return(SendResult.new)
-        expect(state).to receive(:sender_for).with(SMTPSender, endpoint.domain, nil, { rcpt_to: endpoint.address }).and_return(smtp_sender_double)
+        expect(state).to receive(:sender_for).with(SMTPSender, endpoint.domain, ip_address, { rcpt_to: endpoint.address }).and_return(smtp_sender_double)
         processor.process
       end
     end

--- a/spec/models/queued_message_spec.rb
+++ b/spec/models/queued_message_spec.rb
@@ -166,6 +166,20 @@ RSpec.describe QueuedMessage do
           expect { queued_message.allocate_ip_address }.to change(queued_message, :ip_address).from(nil).to(ip_pool.ip_addresses.first)
         end
       end
+
+      context "when an incoming message will be forwarded to an address endpoint" do
+        let(:ip_pool) { create(:ip_pool, :with_ip_address) }
+        let(:server) { create(:server, ip_pool: ip_pool) }
+        let(:endpoint) { create(:address_endpoint, server: server) }
+        let(:route) { create(:route, server: server, mode: "Endpoint", endpoint: endpoint) }
+        let(:message) { MessageFactory.incoming(server, route: route) }
+
+        subject(:queued_message) { create(:queued_message, message: message) }
+
+        it "allocates an IP address from the server's pool" do
+          expect(queued_message.ip_address).to eq ip_pool.ip_addresses.first
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

- allocate an IP address from the configured pool for incoming messages routed to address endpoints
- pass the selected IP address to the SMTP sender used for forwarding
- add regression coverage for IP allocation and SMTP sender construction

## Testing

- `bundle exec rspec spec/models/queued_message_spec.rb spec/models/server_spec.rb spec/lib/message_dequeuer/incoming_message_processor_spec.rb` (201 examples, 0 failures)
- `bundle exec rubocop app/models/server.rb app/lib/message_dequeuer/incoming_message_processor.rb spec/models/queued_message_spec.rb spec/lib/message_dequeuer/incoming_message_processor_spec.rb`

Closes #3109
