### PR TITLE
fix: prevent local loops when routing to the same address

### DIFF
--- a/app/models/additional_route_endpoint.rb
+++ b/app/models/additional_route_endpoint.rb
@@ -20,6 +20,7 @@ class AdditionalRouteEndpoint < ApplicationRecord
   validate :validate_endpoint_belongs_to_server
   validate :validate_wildcard
   validate :validate_uniqueness
+  validate :validate_no_local_loop
 
   def self.find_by_endpoint(endpoint)
     class_name, id = endpoint.split("#", 2)
@@ -68,6 +69,13 @@ class AdditionalRouteEndpoint < ApplicationRecord
     return unless endpoint_type == "SMTPEndpoint" || endpoint_type == "AddressEndpoint"
 
     errors.add :base, "SMTP or address endpoints are not permitted on wildcard routes"
+  end
+
+  def validate_no_local_loop
+    return unless endpoint.is_a?(AddressEndpoint)
+    return unless route&.local_loop_with?(endpoint.address)
+
+    errors.add :base, "cannot deliver mail back to this route's own address"
   end
 
 end

--- a/app/models/address_endpoint.rb
+++ b/app/models/address_endpoint.rb
@@ -22,6 +22,7 @@ class AddressEndpoint < ApplicationRecord
   has_many :additional_route_endpoints, dependent: :destroy, as: :endpoint
 
   validates :address, presence: true, format: { with: /@/ }, uniqueness: { scope: [:server_id], message: "has already been added", case_sensitive: false }
+  validate :validate_no_local_loop
 
   before_destroy :update_routes
 
@@ -39,6 +40,18 @@ class AddressEndpoint < ApplicationRecord
 
   def domain
     address.split("@", 2).last
+  end
+
+  private
+
+  def validate_no_local_loop
+    return if address.blank?
+
+    looping_route = routes.detect { |route| route.local_loop_with?(address) } ||
+                    additional_route_endpoints.map(&:route).compact.detect { |route| route.local_loop_with?(address) }
+    return unless looping_route
+
+    errors.add :address, "cannot deliver mail back to this route's own address"
   end
 
 end

--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -45,6 +45,7 @@ class Route < ApplicationRecord
   validate :validate_name_uniqueness
   validate :validate_return_path_route_endpoints
   validate :validate_no_additional_routes_on_non_endpoint_route
+  validate :validate_no_local_loop
 
   after_save :save_additional_route_endpoints
 
@@ -58,8 +59,21 @@ class Route < ApplicationRecord
     if return_path?
       "Return Path"
     else
-      "#{name}@#{domain.name}"
+      incoming_address
     end
+  end
+
+  def incoming_address
+    return if return_path? || domain.blank? || name.blank?
+
+    "#{name}@#{domain.name}"
+  end
+
+  def local_loop_with?(address)
+    incoming = incoming_address
+    return false if incoming.blank? || address.blank?
+
+    incoming.casecmp?(address.to_s)
   end
 
   def _endpoint
@@ -217,6 +231,13 @@ class Route < ApplicationRecord
     return unless mode != "Endpoint" && !additional_route_endpoints_array.empty?
 
     errors.add :base, "Additional routes are not permitted unless the primary route is an actual endpoint"
+  end
+
+  def validate_no_local_loop
+    return unless mode == "Endpoint" && endpoint.is_a?(AddressEndpoint)
+    return unless local_loop_with?(endpoint.address)
+
+    errors.add :endpoint, "cannot deliver mail back to this route's own address"
   end
 
   class << self


### PR DESCRIPTION
## Summary

- reject Address Endpoints that would deliver mail back to the route's own incoming address
- apply the same check when adding extra endpoints or later changing an Address Endpoint address
- compare addresses case-insensitively so `User@Example.com` cannot bypass `user@example.com`

This stops a misconfigured self-forward (route `user@example.com` pointing at Address Endpoint `user@example.com`) from generating unbounded mail.

## Test plan

- [ ] Create a route for `user@example.com` that forwards to Address Endpoint `user@example.com` and confirm save fails
- [ ] Repeat with mixed-case addresses (`User@Example.com`) and confirm it is also rejected
- [ ] Add the same address as an additional endpoint on an otherwise valid route and confirm save fails
- [ ] Change an existing Address Endpoint to the route's own address and confirm save fails
- [ ] Forward `user@example.com` to a different address and confirm save still succeeds

Made with [Cursor](https://cursor.com)