### PR TITLE
feat: add configurable Postal logger level defaulting to INFO

### DIFF
--- a/doc/config/environment-variables.md
+++ b/doc/config/environment-variables.md
@@ -43,6 +43,7 @@ This document contains all the environment variables which are available for thi
 | `LOGGING_RAILS_LOG_ENABLED` | Boolean | Enable the default Rails logger | false |
 | `LOGGING_SENTRY_DSN` | String | A DSN which should be used to report exceptions to Sentry |  |
 | `LOGGING_ENABLED` | Boolean | Enable the Postal logger to log to STDOUT | true |
+| `LOGGING_LEVEL` | String | The minimum log level for the Postal logger (debug, info, warn, error, fatal) | INFO |
 | `LOGGING_HIGHLIGHTING_ENABLED` | Boolean | Enable highlighting of log lines | false |
 | `GELF_HOST` | String | GELF-capable host to send logs to |  |
 | `GELF_PORT` | Integer | GELF port to send logs to | 12201 |

--- a/doc/config/yaml.yml
+++ b/doc/config/yaml.yml
@@ -89,6 +89,8 @@ logging:
   sentry_dsn: 
   # Enable the Postal logger to log to STDOUT
   enabled: true
+  # The minimum log level for the Postal logger (debug, info, warn, error, fatal)
+  level: INFO
   # Enable highlighting of log lines
   highlighting_enabled: false
 

--- a/lib/postal/config.rb
+++ b/lib/postal/config.rb
@@ -82,6 +82,7 @@ module Postal
     def logger
       @logger ||= begin
         k = Klogger.new(nil, destination: Config.logging.enabled? ? $stdout : "/dev/null", highlight: Config.logging.highlighting_enabled?)
+        k.level = Config.logging.level
         k.add_destination(graylog_logging_destination) if Config.gelf.host.present?
         k
       end

--- a/lib/postal/config_schema.rb
+++ b/lib/postal/config_schema.rb
@@ -232,6 +232,7 @@ module Postal
         default "INFO"
         transform do |value|
           normalized = value.to_s.strip.downcase
+          normalized = "info" if normalized.empty?
           unless %w[debug info warn error fatal].include?(normalized)
             raise ArgumentError, "logging.level must be one of: debug, info, warn, error, fatal (got #{value.inspect})"
           end

--- a/lib/postal/config_schema.rb
+++ b/lib/postal/config_schema.rb
@@ -227,6 +227,18 @@ module Postal
         default true
       end
 
+      string :level do
+        description "The minimum log level for the Postal logger (debug, info, warn, error, fatal)"
+        default "INFO"
+        transform do |value|
+          normalized = value.to_s.strip.downcase
+          unless %w[debug info warn error fatal].include?(normalized)
+            raise ArgumentError, "logging.level must be one of: debug, info, warn, error, fatal (got #{value.inspect})"
+          end
+          normalized
+        end
+      end
+
       boolean :highlighting_enabled do
         description "Enable highlighting of log lines"
         default false


### PR DESCRIPTION
## Summary
- Add a `logging.level` config option (and `LOGGING_LEVEL` env var) so the Postal logger threshold can be set without code changes.
- Default the logger to INFO instead of Klogger's DEBUG, while still allowing debug / info / warn / error / fatal.

## Test plan
- [ ] Start Postal with no `logging.level` set and confirm DEBUG lines are not emitted.
- [ ] Set `logging.level: debug` (or `LOGGING_LEVEL=debug`) and confirm DEBUG logs appear.
- [ ] Set an invalid value (e.g. `verbose`) and confirm startup fails with a clear error.

Made with [Cursor](https://cursor.com)