### PR TITLE
fix: give each worker process a unique locker identity

### DIFF
--- a/lib/postal/config.rb
+++ b/lib/postal/config.rb
@@ -11,6 +11,7 @@ require "konfig/sources/environment"
 require "konfig/sources/yaml"
 require "dotenv"
 require "klogger"
+require "securerandom"
 
 require_relative "error"
 require_relative "config_schema"
@@ -87,11 +88,15 @@ module Postal
       end
     end
 
+    def process_identity
+      @process_identity ||= SecureRandom.hex(8)
+    end
+
     def process_name
       @process_name ||= begin
-        "host:#{Socket.gethostname} pid:#{Process.pid}"
+        "host:#{Socket.gethostname} pid:#{Process.pid} id:#{process_identity}"
       rescue StandardError
-        "pid:#{Process.pid}"
+        "pid:#{Process.pid} id:#{process_identity}"
       end
     end
 


### PR DESCRIPTION
## Summary
- `Postal.locker_name` was `host:<hostname> pid:<pid> thread:<id>`. Docker workers often share hostname and PID, so every process renewed the same `worker_roles` row and ran scheduled tasks concurrently.
- Add a per-process random id to `process_name` so each worker has a distinct locker identity.

Fixes #3627

## Test plan
- [ ] Run two or more worker containers with the same hostname.
- [ ] Confirm `worker_roles.worker` contains different `id:` values after restart.
- [ ] Confirm only one worker logs `running task` / `checking DNS` for `CheckAllDNSScheduledTask` at `:15`.

Made with [Cursor](https://cursor.com)