### PR TITLE
fix: renew tasks lock so long jobs are not stolen

### DIFF
--- a/app/lib/worker/process.rb
+++ b/app/lib/worker/process.rb
@@ -44,6 +44,8 @@ module Worker
       TidyQueuedMessagesTask,
     ].freeze
 
+    TASK_LOCK_RENEW_INTERVAL = 30
+
     # @param [Integer] thread_count The number of worker threads to run in this process
     def initialize(thread_count: Postal::Config.worker.threads,
                    work_sleep_time: 5,
@@ -103,12 +105,12 @@ module Worker
     # @return [void]
     def ensure_connection_pool_size_is_suitable
       current_pool_size = ActiveRecord::Base.connection_pool.size
-      desired_pool_size = @thread_count + 3
+      desired_pool_size = @thread_count + 4
 
       return if current_pool_size >= desired_pool_size
 
       logger.warn "number of worker threads (#{@thread_count}) is more  " \
-                  "than the db connection pool size (#{current_pool_size}+3), " \
+                  "than the db connection pool size (#{current_pool_size}+4), " \
                   "increasing connection pool size to #{desired_pool_size}"
 
       Postal.change_database_connection_pool_size(desired_pool_size)
@@ -191,8 +193,9 @@ module Worker
       logger.info "starting tasks thread"
       @threads << Thread.new do
         logger.tagged(component: "worker", thread: "tasks") do
+          tasks_worker = Postal.locker_name
           loop do
-            run_tasks
+            run_tasks(tasks_worker)
 
             if shutdown_after_wait?(@task_sleep_time)
               break
@@ -201,7 +204,7 @@ module Worker
 
           logger.info "stopping tasks thread"
           ActiveRecord::Base.connection_pool.with_connection do
-            if WorkerRole.release(:tasks)
+            if WorkerRole.release(:tasks, worker: tasks_worker)
               logger.info "released tasks role"
             end
           end
@@ -212,10 +215,11 @@ module Worker
     # Run the tasks. This will attempt to acquire the tasks role and if successful it will all the registered
     # tasks if they are due to be run.
     #
+    # @param tasks_worker [String] Stable locker identity for this tasks thread
     # @return [void]
-    def run_tasks
+    def run_tasks(tasks_worker = Postal.locker_name)
       role_acquisition_status = ActiveRecord::Base.connection_pool.with_connection do
-        WorkerRole.acquire(:tasks)
+        WorkerRole.acquire(:tasks, worker: tasks_worker)
       end
 
       case role_acquisition_status
@@ -230,9 +234,41 @@ module Worker
         return false
       end
 
-      ActiveRecord::Base.connection_pool.with_connection do
-        TASKS.each { |task| run_task(task) }
+      with_task_lock_heartbeat(tasks_worker) do
+        ActiveRecord::Base.connection_pool.with_connection do
+          TASKS.each { |task| run_task(task) }
+        end
       end
+    end
+
+    # Keep acquired_at fresh while a long task is running so another worker cannot steal the role.
+    #
+    # @param tasks_worker [String]
+    # @return [void]
+    def with_task_lock_heartbeat(tasks_worker)
+      stop = false
+      heartbeat = Thread.new do
+        elapsed = 0
+        until stop
+          sleep 1
+          elapsed += 1
+          next if elapsed < TASK_LOCK_RENEW_INTERVAL || stop
+
+          elapsed = 0
+          capture_errors do
+            ActiveRecord::Base.connection_pool.with_connection do
+              unless WorkerRole.renew(:tasks, worker: tasks_worker)
+                logger.warn "lost tasks role while running scheduled tasks"
+              end
+            end
+          end
+        end
+      end
+
+      yield
+    ensure
+      stop = true
+      heartbeat&.join(5)
     end
 
     # Run a single task

--- a/app/models/worker_role.rb
+++ b/app/models/worker_role.rb
@@ -15,38 +15,57 @@
 #
 class WorkerRole < ApplicationRecord
 
+  STALE_AFTER = 5.minutes
+
   class << self
 
     # Acquire or renew a lock for the given role.
     #
     # @param role [String] The name of the role to acquire
+    # @param worker [String] The worker identity that should own the lock
     # @return [Symbol, false] True if the lock was acquired or renewed, false otherwise
-    def acquire(role)
+    def acquire(role, worker: Postal.locker_name)
       # update our existing lock if we already have one
-      updates = where(role: role, worker: Postal.locker_name).update_all(acquired_at: Time.current)
+      updates = where(role: role, worker: worker).update_all(acquired_at: Time.current)
       return :renewed if updates.positive?
 
       # attempt to steal a role from another worker
-      updates = where(role: role).where("acquired_at is null OR acquired_at < ?", 5.minutes.ago)
-                                 .update_all(acquired_at: Time.current, worker: Postal.locker_name)
+      updates = where(role: role).where("acquired_at is null OR acquired_at < ?", STALE_AFTER.ago)
+                                 .update_all(acquired_at: Time.current, worker: worker)
       return :stolen if updates.positive?
 
       # attempt to create a new role for this worker
       begin
-        create!(role: role, worker: Postal.locker_name, acquired_at: Time.current)
+        create!(role: role, worker: worker, acquired_at: Time.current)
         :created
       rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid
         false
       end
+    rescue ActiveRecord::StatementInvalid
+      false
+    end
+
+    # Refresh acquired_at so a long-running holder is not treated as stale.
+    #
+    # @param role [String]
+    # @param worker [String]
+    # @return [Boolean]
+    def renew(role, worker: Postal.locker_name)
+      where(role: role, worker: worker).update_all(acquired_at: Time.current).positive?
+    rescue ActiveRecord::StatementInvalid
+      false
     end
 
     # Release a lock for the given role for the current process.
     #
     # @param role [String] The name of the role to release
+    # @param worker [String] The worker identity that owns the lock
     # @return [Boolean] True if the lock was released, false otherwise
-    def release(role)
-      updates = where(role: role, worker: Postal.locker_name).delete_all
+    def release(role, worker: Postal.locker_name)
+      updates = where(role: role, worker: worker).delete_all
       updates.positive?
+    rescue ActiveRecord::StatementInvalid
+      false
     end
 
   end


### PR DESCRIPTION
## Summary
- The `:tasks` role is only renewed at the start of each `run_tasks` cycle. If a scheduled task (retention, CheckAllDNS, …) runs longer than 5 minutes, another worker steals the lock and runs the same work concurrently.
- Renew `acquired_at` every 30 seconds while tasks are running, using a stable locker name captured on the tasks thread.
- Treat Galera/MySQL `StatementInvalid` on lock updates as a failed acquire instead of crashing the tasks thread.

Addresses the lock-steal race described in #3595.

## Test plan
- [ ] Run two workers and a long scheduled task (> 5 minutes).
- [ ] Confirm the second worker does not log `acquired task role by stealing it from a lazy worker` while the first is still running tasks.
- [ ] Confirm `worker_roles.acquired_at` keeps moving forward during the long task.
- [ ] Stop the holder; after ~5 minutes another worker can steal the role.

Made with [Cursor](https://cursor.com)