### PR TITLE
feat: add v2 control plane API

### DIFF
--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+module API
+  module V2
+    class BaseController < ActionController::API
+
+      include Idempotency
+
+      # Authie extends ActionController::API globally. Bearer-authenticated
+      # control requests deliberately do not create browser sessions/cookies.
+      skip_before_action :set_browser_id, raise: false
+      skip_before_action :validate_auth_session, raise: false
+      prepend_before_action :skip_touch_auth_session!
+
+      MAX_PAGE_SIZE = 100
+      DEFAULT_PAGE_SIZE = 25
+      RATE_LIMIT = 300
+      RATE_LIMIT_WINDOW = 5.minutes
+
+      before_action :set_request_id
+      before_action :authenticate_control_api_key!
+      before_action :enforce_rate_limit!
+
+      rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+      rescue_from ActionController::ParameterMissing, with: :parameter_missing
+      rescue_from ActionController::UnpermittedParameters, with: :unpermitted_parameters
+      rescue_from ActiveRecord::RecordInvalid, with: :record_invalid
+
+      private
+
+      attr_reader :current_control_api_key
+
+      def authenticate_control_api_key!
+        header = request.authorization.to_s
+        token = header[/\ABearer\s+([^\s]+)\z/i, 1]
+        return render_error("unauthorized", "A bearer token is required", status: :unauthorized) unless token
+
+        @current_control_api_key = ControlAPIKey.authenticate(token)
+        render_error("unauthorized", "The bearer token is invalid, expired, or revoked", status: :unauthorized) unless @current_control_api_key
+      end
+
+      def require_scope!(scope)
+        return if current_control_api_key&.allows?(scope)
+
+        render_error("forbidden", "This API key does not have the required scope", status: :forbidden)
+      end
+
+      def organization_scope!(organization)
+        return true if current_control_api_key.platform_admin?
+        return true if current_control_api_key.organization_id == organization.id
+
+        render_error("not_found", "The requested resource could not be found", status: :not_found)
+        false
+      end
+
+      def scoped_organization!(uuid = params[:organization_uuid] || params[:uuid])
+        organization = Organization.present.find_by!(uuid: uuid)
+        organization_scope!(organization) ? organization : nil
+      end
+
+      def render_data(data, status: :ok, meta: nil)
+        body = { data: data, meta: meta || {}, error: nil }
+        response.set_header("X-Request-Id", request_id)
+        render json: body, status: status
+      end
+
+      def render_error(code, message, status:, details: {})
+        response.set_header("X-Request-Id", request_id)
+        render json: { data: nil, meta: {}, error: { code: code, message: message, details: details } }, status: status
+      end
+
+      def pagination_for(scope)
+        page = [params.fetch(:page, 1).to_i, 1].max
+        per_page = params.fetch(:per_page, DEFAULT_PAGE_SIZE).to_i.clamp(1, MAX_PAGE_SIZE)
+        [scope.offset((page - 1) * per_page).limit(per_page), { page: page, per_page: per_page }]
+      end
+
+      def audit!(organization:, resource:, action:, before: {}, after: {})
+        AuditEvent.create!(actor_uuid: current_control_api_key.uuid, organization_uuid: organization.uuid,
+                           resource_type: resource.class.name, resource_uuid: resource.uuid, action: action,
+                           request_id: request_id, source_ip: request.remote_ip,
+                           before_metadata: safe_metadata(before), after_metadata: safe_metadata(after), occurred_at: Time.current)
+      end
+
+      attr_reader :request_id
+
+      def set_request_id
+        @request_id = request.headers["X-Request-Id"].presence || SecureRandom.uuid
+      end
+
+      def enforce_rate_limit!
+        key = "control-api-rate-limit/#{current_control_api_key.uuid}/#{Time.current.to_i / RATE_LIMIT_WINDOW.to_i}"
+        count = Rails.cache.increment(key, 1, expires_in: RATE_LIMIT_WINDOW)
+        return if count <= RATE_LIMIT
+
+        render_error("rate_limited", "Too many requests", status: :too_many_requests)
+      end
+
+      def record_not_found
+        render_error("not_found", "The requested resource could not be found", status: :not_found)
+      end
+
+      def parameter_missing(exception)
+        render_error("invalid_request", "A required parameter is missing", status: :bad_request, details: { parameter: exception.param })
+      end
+
+      def unpermitted_parameters(exception)
+        render_error("invalid_request", "The request contains unsupported parameters", status: :unprocessable_content, details: { parameters: exception.params })
+      end
+
+      def record_invalid(exception)
+        render_error("validation_failed", "The request could not be processed", status: :unprocessable_content, details: exception.record.errors.to_hash)
+      end
+
+      def safe_metadata(value)
+        filtered = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters).filter(value.to_h)
+        JSON.parse(JSON.generate(filtered))
+      end
+
+    end
+  end
+end

--- a/app/controllers/api/v2/credentials_controller.rb
+++ b/app/controllers/api/v2/credentials_controller.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module API
+  module V2
+    class CredentialsController < BaseController
+
+      before_action { @organization = scoped_organization!(params[:organization_uuid]) }
+      before_action { @server = @organization&.servers&.present&.find_by!(uuid: params[:server_uuid]) }
+      before_action(only: :rotate) do
+        @credential = @server&.credentials&.find_by!(uuid: params[:uuid])
+      end
+      before_action(only: :destroy) { @credential = @server&.credentials&.find_by(uuid: params[:uuid]) }
+
+      def index
+        require_scope!("servers:read")
+        return if performed? || @server.nil?
+
+        scope, meta = pagination_for(@server.credentials.order(:name))
+        render_data(scope.map { |credential| serialize(credential) }, meta: meta)
+      end
+
+      def create
+        require_scope!("credentials:write")
+        return if performed? || @server.nil?
+
+        with_idempotency do
+          credential = @server.credentials.create!(credential_params)
+          audit!(organization: @organization, resource: credential, action: "credential.created", after: serialize(credential))
+          render_data(serialize(credential, include_secret: true), status: :created)
+        end
+      end
+
+      def destroy
+        require_scope!("credentials:write")
+        return if performed? || @server.nil?
+
+        with_idempotency do
+          return render_error("not_found", "The requested resource could not be found", status: :not_found) unless @credential
+
+          audit!(organization: @organization, resource: @credential, action: "credential.revoked", before: serialize(@credential))
+          @credential.destroy!
+          head :no_content
+        end
+      end
+
+      def rotate
+        require_scope!("credentials:write")
+        return if performed? || @credential.nil?
+        return render_error("credential_rotation_unsupported", "SMTP-IP credentials cannot be rotated", status: :unprocessable_content) if @credential.type == "SMTP-IP"
+
+        with_idempotency do
+          replacement = @server.credentials.create!(type: @credential.type, name: @credential.name, hold: @credential.hold, options: @credential.options)
+          audit!(organization: @organization, resource: @credential, action: "credential.rotated", before: serialize(@credential), after: serialize(replacement))
+          @credential.destroy!
+          render_data(serialize(replacement, include_secret: true), status: :created)
+        end
+      end
+
+      private
+
+      def credential_params
+        params.permit(:type, :name, :key, :hold)
+      end
+
+      def serialize(credential, include_secret: false)
+        data = { uuid: credential.uuid, name: credential.name, type: credential.type, hold: credential.hold, last_used_at: credential.last_used_at,
+                 key_hint: credential.key.present? ? "…#{credential.key.last(4)}" : nil, created_at: credential.created_at }
+        data[:key] = credential.key if include_secret
+        data
+      end
+
+    end
+  end
+end

--- a/app/controllers/api/v2/domains_controller.rb
+++ b/app/controllers/api/v2/domains_controller.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+module API
+  module V2
+    class DomainsController < BaseController
+
+      before_action { @organization = scoped_organization!(params[:organization_uuid]) }
+      before_action { @server = @organization&.servers&.present&.find_by!(uuid: params[:server_uuid]) }
+      before_action(only: [:show, :destroy, :verify, :check_dns]) do
+        @domain = @server&.domains&.find_by!(uuid: params[:uuid])
+      end
+
+      def index
+        require_scope!("domains:read")
+        return if performed? || @server.nil?
+
+        scope, meta = pagination_for(@server.domains.order(:name))
+        render_data(scope.map { |domain| serialize(domain) }, meta: meta)
+      end
+
+      def show
+        require_scope!("domains:read")
+        return if performed? || @domain.nil?
+
+        render_data(serialize(@domain))
+      end
+
+      def create
+        require_scope!("domains:write")
+        return if performed? || @server.nil?
+
+        with_idempotency do
+          domain = @server.domains.create!(domain_params)
+          audit!(organization: @organization, resource: domain, action: "domain.created", after: serialize(domain))
+          render_data(serialize(domain), status: :created)
+        end
+      end
+
+      def destroy
+        require_scope!("domains:write")
+        return if performed? || @domain.nil?
+
+        with_idempotency do
+          @domain.destroy!
+          audit!(organization: @organization, resource: @domain, action: "domain.deleted")
+          head :no_content
+        end
+      end
+
+      def verify
+        require_scope!("domains:write")
+        return if performed? || @domain.nil?
+
+        with_idempotency do
+          @domain.verify_with_dns
+          audit!(organization: @organization, resource: @domain, action: "domain.verify_requested", after: serialize(@domain))
+          render_data(serialize(@domain))
+        end
+      end
+
+      def check_dns
+        require_scope!("domains:write")
+        return if performed? || @domain.nil?
+
+        with_idempotency do
+          @domain.check_dns(:manual)
+          audit!(organization: @organization, resource: @domain, action: "domain.dns_checked", after: serialize(@domain))
+          render_data(serialize(@domain))
+        end
+      end
+
+      private
+
+      def domain_params
+        params.permit(:name, :verification_method, :outgoing, :incoming, :use_for_any).tap do |attributes|
+          attributes[:verification_method] ||= "DNS"
+        end
+      end
+
+      def serialize(domain)
+        {
+          uuid: domain.uuid, name: domain.name, verified: domain.verified?, verification_method: domain.verification_method,
+          dns_records: {
+            verification: { type: "TXT", name: domain.name, value: domain.dns_verification_string },
+            spf: { type: "TXT", name: domain.name, value: domain.spf_record },
+            dkim: { type: "TXT", name: "#{domain.dkim_record_name}.#{domain.name}", value: domain.dkim_record },
+            return_path: { type: "CNAME", name: domain.return_path_domain, value: Postal::Config.dns.return_path_domain },
+            mx: Array(Postal::Config.dns.mx_records)
+          },
+          dns_status: { checked_at: domain.dns_checked_at, spf: status(domain, :spf), dkim: status(domain, :dkim), mx: status(domain, :mx), return_path: status(domain, :return_path) }
+        }
+      end
+
+      def status(domain, type)
+        { status: domain.public_send("#{type}_status"), error: domain.public_send("#{type}_error") }
+      end
+
+    end
+  end
+end

--- a/app/controllers/api/v2/domains_controller.rb
+++ b/app/controllers/api/v2/domains_controller.rb
@@ -63,9 +63,11 @@ module API
         return if performed? || @domain.nil?
 
         with_idempotency do
+          @domain.verify_with_dns unless @domain.verified?
           @domain.check_dns(:manual)
-          audit!(organization: @organization, resource: @domain, action: "domain.dns_checked", after: serialize(@domain))
-          render_data(serialize(@domain))
+          dmarc = dmarc_status(@domain)
+          audit!(organization: @organization, resource: @domain, action: "domain.dns_checked", after: serialize(@domain, dmarc: dmarc))
+          render_data(serialize(@domain, dmarc: dmarc))
         end
       end
 
@@ -77,22 +79,35 @@ module API
         end
       end
 
-      def serialize(domain)
+      def serialize(domain, dmarc: nil)
         {
-          uuid: domain.uuid, name: domain.name, verified: domain.verified?, verification_method: domain.verification_method,
+          uuid: domain.uuid, name: domain.name, verified: domain.verified?, use_for_any: domain.use_for_any?, verification_method: domain.verification_method,
           dns_records: {
             verification: { type: "TXT", name: domain.name, value: domain.dns_verification_string },
             spf: { type: "TXT", name: domain.name, value: domain.spf_record },
             dkim: { type: "TXT", name: "#{domain.dkim_record_name}.#{domain.name}", value: domain.dkim_record },
+            dmarc: { type: "TXT", name: "_dmarc.#{domain.name}", value: "v=DMARC1; p=none; adkim=s; aspf=s" },
             return_path: { type: "CNAME", name: domain.return_path_domain, value: Postal::Config.dns.return_path_domain },
             mx: Array(Postal::Config.dns.mx_records)
           },
-          dns_status: { checked_at: domain.dns_checked_at, spf: status(domain, :spf), dkim: status(domain, :dkim), mx: status(domain, :mx), return_path: status(domain, :return_path) }
+          dns_status: { checked_at: domain.dns_checked_at, spf: status(domain, :spf), dkim: status(domain, :dkim), dmarc: dmarc || { status: "Pending", error: "Run Check DNS to verify the DMARC record." }, mx: status(domain, :mx), return_path: status(domain, :return_path) }
         }
       end
 
       def status(domain, type)
         { status: domain.public_send("#{type}_status"), error: domain.public_send("#{type}_error") }
+      end
+
+      def dmarc_status(domain)
+        records = domain.resolver.txt("_dmarc.#{domain.name}")
+        record = records.find { |value| value.match?(/\Av=DMARC1(?:;|\s|$)/i) }
+        return { status: "Missing", error: "No DMARC record exists for this domain." } if record.nil?
+
+        return { status: "Invalid", error: "The DMARC record must include a valid p= policy." } unless record.match?(/(?:\A|;)\s*p=(?:none|quarantine|reject)(?:;|\s|$)/i)
+
+        { status: "OK", error: nil }
+      rescue DNSResolver::LocalResolversUnavailableError, Resolv::ResolvError
+        { status: "Pending", error: "Unable to check DMARC right now. Try again shortly." }
       end
 
     end

--- a/app/controllers/api/v2/health_controller.rb
+++ b/app/controllers/api/v2/health_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module API
+  module V2
+    class HealthController < BaseController
+
+      def show
+        require_scope!("usage:read")
+        return if performed?
+
+        render_data({ status: "ok" })
+      end
+
+      def server
+        organization = scoped_organization!(params[:organization_uuid])
+        return if performed? || organization.nil?
+
+        require_scope!("usage:read")
+        return if performed?
+
+        server = organization.servers.present.find_by!(uuid: params[:uuid])
+        total, unverified, bad_dns = server.domain_stats
+        render_data({ status: server.suspended? ? "suspended" : "ok", queue_size: server.queue_size,
+                      domains: { total: total, unverified: unverified, dns_errors: bad_dns }, rolling_send_limit: server.throughput_stats })
+      end
+
+    end
+  end
+end

--- a/app/controllers/api/v2/incoming_routes_controller.rb
+++ b/app/controllers/api/v2/incoming_routes_controller.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "uri"
+
+module API
+  module V2
+    class IncomingRoutesController < BaseController
+
+      before_action { @organization = scoped_organization!(params[:organization_uuid]) }
+      before_action { @server = @organization&.servers&.present&.find_by!(uuid: params[:server_uuid]) }
+
+      def index
+        require_scope!("servers:read")
+        return if performed? || @server.nil?
+
+        scope, meta = pagination_for(@server.routes.includes(:domain, :endpoint).order(:name))
+        render_data(scope.map { |route| serialize(route) }, meta: meta)
+      end
+
+      def create
+        require_scope!("servers:write")
+        return if performed? || @server.nil?
+
+        with_idempotency do
+          domain = @server.domains.find_by!(uuid: incoming_route_params.fetch(:domain_uuid))
+          return render_error("domain_not_verified", "Verify the sending domain before enabling incoming mail", status: :unprocessable_content) unless domain.verified?
+
+          route = ApplicationRecord.transaction do
+            endpoint = create_endpoint!(incoming_route_params.fetch(:destination))
+            domain.update!(incoming: true)
+            @server.routes.create!(name: incoming_route_params.fetch(:name), domain: domain, spam_mode: "Mark", _endpoint: "#{endpoint.class}##{endpoint.uuid}")
+          end
+          audit!(organization: @organization, resource: route, action: "incoming_route.created", after: serialize(route))
+          render_data(serialize(route), status: :created)
+        end
+      rescue Postal::HTTP::BlockedDestinationError, URI::InvalidURIError, SocketError
+        render_error("unsafe_http_endpoint", "The HTTP endpoint URL is not permitted", status: :unprocessable_content)
+      end
+
+      private
+
+      def incoming_route_params
+        params.permit(:domain_uuid, :name, destination: [:type, :address, :url, :hostname, :port, :ssl_mode])
+      end
+
+      def create_endpoint!(destination)
+        type = destination.fetch(:type)
+        case type
+        when "address"
+          @server.address_endpoints.create!(address: destination.fetch(:address))
+        when "http"
+          validate_http_destination!(destination.fetch(:url))
+          @server.http_endpoints.create!(name: "Incoming #{incoming_route_params.fetch(:name)}", url: destination.fetch(:url), encoding: "BodyAsJSON", format: "Hash", include_attachments: true, strip_replies: false)
+        when "smtp"
+          @server.smtp_endpoints.create!(name: "Incoming #{incoming_route_params.fetch(:name)}", hostname: destination.fetch(:hostname), port: destination[:port].presence, ssl_mode: destination.fetch(:ssl_mode, "STARTTLS"))
+        else
+          raise ActionController::ParameterMissing, "destination.type"
+        end
+      end
+
+      def validate_http_destination!(url)
+        uri = URI.parse(url)
+        raise URI::InvalidURIError unless uri.is_a?(URI::HTTPS) && uri.host.present?
+
+        Postal::HTTP::AddressGuard.safe_connect_address(uri.host)
+      end
+
+      def serialize(route)
+        endpoint = route.endpoint
+        {
+          uuid: route.uuid, name: route.name, domain_uuid: route.domain&.uuid, domain: route.domain&.name, mode: route.mode,
+          enabled: route.mode == "Endpoint", endpoint: endpoint && { type: endpoint.class.name.delete_suffix("Endpoint").downcase, description: endpoint.description },
+          created_at: route.created_at
+        }
+      end
+
+    end
+  end
+end

--- a/app/controllers/api/v2/organizations_controller.rb
+++ b/app/controllers/api/v2/organizations_controller.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+module API
+  module V2
+    class OrganizationsController < BaseController
+
+      before_action only: [:show, :update, :destroy, :suspend, :unsuspend] do
+        @organization = scoped_organization!(params[:uuid])
+      end
+
+      def index
+        require_scope!("organizations:read")
+        return if performed?
+
+        if current_control_api_key.platform_admin?
+          scope = Organization.present.order(:created_at)
+        else
+          scope = Organization.present.where(id: current_control_api_key.organization_id).order(:created_at)
+        end
+        records, meta = pagination_for(scope)
+        render_data(records.map { |organization| serialize(organization) }, meta: meta.merge(total: scope.count))
+      end
+
+      def show
+        require_scope!("organizations:read")
+        return if performed? || @organization.nil?
+
+        render_data(serialize(@organization))
+      end
+
+      def create
+        require_scope!("organizations:write")
+        return if performed?
+        return render_error("forbidden", "Only platform API keys can create organizations", status: :forbidden) unless current_control_api_key.platform_admin?
+
+        with_idempotency do
+          organization = nil
+          Organization.transaction do
+            owner = find_or_create_owner!(owner_params)
+            organization = Organization.create!(organization_params.merge(owner: owner))
+            OrganizationUser.where(organization: organization, user: owner).first_or_create!.update!(admin: true, all_servers: true)
+          end
+          audit!(organization: organization, resource: organization, action: "organization.created", after: serialize(organization))
+          render_data(serialize(organization), status: :created)
+        end
+      end
+
+      def update
+        require_scope!("organizations:write")
+        return if performed? || @organization.nil?
+
+        before = serialize(@organization)
+        @organization.update!(organization_params.except(:external_customer_id))
+        audit!(organization: @organization, resource: @organization, action: "organization.updated", before: before, after: serialize(@organization))
+        render_data(serialize(@organization))
+      end
+
+      def destroy
+        require_scope!("organizations:write")
+        return if performed? || @organization.nil?
+
+        with_idempotency do
+          @organization.soft_destroy
+          audit!(organization: @organization, resource: @organization, action: "organization.deleted")
+          head :no_content
+        end
+      end
+
+      def suspend
+        lifecycle(:suspend)
+      end
+
+      def unsuspend
+        lifecycle(:unsuspend)
+      end
+
+      private
+
+      def lifecycle(operation)
+        require_scope!("organizations:write")
+        return if performed? || @organization.nil?
+
+        with_idempotency do
+          before = serialize(@organization)
+          operation == :suspend ? @organization.suspend(params[:reason].to_s) : @organization.unsuspend
+          audit!(organization: @organization, resource: @organization, action: "organization.#{operation}ed", before: before, after: serialize(@organization))
+          render_data(serialize(@organization))
+        end
+      end
+
+      def organization_params
+        params.permit(:name, :permalink, :time_zone, :external_customer_id, :plan_code,
+                      :monthly_outbound_limit, :quota_warning_percent, :quota_action)
+      end
+
+      def owner_params
+        params.require(:owner).permit(:email_address, :first_name, :last_name)
+      end
+
+      def find_or_create_owner!(attributes)
+        User.find_by(email_address: attributes[:email_address]) || User.create!(attributes.merge(password: SecureRandom.urlsafe_base64(48)))
+      rescue ActiveRecord::RecordNotUnique
+        User.find_by!(email_address: attributes[:email_address])
+      end
+
+      def serialize(organization)
+        {
+          uuid: organization.uuid, name: organization.name, permalink: organization.permalink, time_zone: organization.time_zone,
+          status: organization.status.downcase, suspension_reason: organization.suspension_reason,
+          external_customer_id: organization.external_customer_id, plan_code: organization.plan_code,
+          monthly_outbound_limit: organization.monthly_outbound_limit, quota_warning_percent: organization.quota_warning_percent,
+          quota_action: organization.quota_action, created_at: organization.created_at, updated_at: organization.updated_at
+        }
+      end
+
+    end
+  end
+end

--- a/app/controllers/api/v2/servers_controller.rb
+++ b/app/controllers/api/v2/servers_controller.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+module API
+  module V2
+    class ServersController < BaseController
+
+      before_action { @organization = scoped_organization!(params[:organization_uuid]) }
+      before_action only: [:show, :update, :destroy, :suspend, :unsuspend] do
+        @server = @organization&.servers&.present&.find_by!(uuid: params[:uuid])
+      end
+
+      rescue_from ControlPlane::ProvisionServer::ProvisioningError do
+        render_error("provisioning_failed", "The mail server could not be provisioned", status: :unprocessable_content)
+      end
+
+      def index
+        require_scope!("servers:read")
+        return if performed? || @organization.nil?
+
+        scope = @organization.servers.present.order(:created_at)
+        records, meta = pagination_for(scope)
+        render_data(records.map { |server| serialize(server) }, meta: meta.merge(total: scope.count))
+      end
+
+      def show
+        require_scope!("servers:read")
+        return if performed? || @server.nil?
+
+        render_data(serialize(@server))
+      end
+
+      def create
+        require_scope!("servers:write")
+        return if performed? || @organization.nil?
+
+        with_idempotency do
+          server = ControlPlane::ProvisionServer.new(organization: @organization, attributes: server_params).call
+          audit!(organization: @organization, resource: server, action: "server.created", after: serialize(server))
+          render_data(serialize(server), status: :created)
+        end
+      end
+
+      def update
+        require_scope!("servers:write")
+        return if performed? || @server.nil?
+
+        before = serialize(@server)
+        @server.update!(server_params)
+        audit!(organization: @organization, resource: @server, action: "server.updated", before: before, after: serialize(@server))
+        render_data(serialize(@server))
+      end
+
+      def destroy
+        require_scope!("servers:write")
+        return if performed? || @server.nil?
+
+        @server.soft_destroy
+        audit!(organization: @organization, resource: @server, action: "server.deleted")
+        head :no_content
+      end
+
+      def suspend
+        lifecycle(:suspend)
+      end
+
+      def unsuspend
+        lifecycle(:unsuspend)
+      end
+
+      private
+
+      def lifecycle(operation)
+        require_scope!("servers:write")
+        return if performed? || @server.nil?
+
+        with_idempotency do
+          before = serialize(@server)
+          operation == :suspend ? @server.suspend(params[:reason].to_s) : @server.unsuspend
+          audit!(organization: @organization, resource: @server, action: "server.#{operation}ed", before: before, after: serialize(@server))
+          render_data(serialize(@server))
+        end
+      end
+
+      def server_params
+        params.permit(:name, :permalink, :mode, :send_limit, :message_retention_days, :raw_message_retention_days,
+                      :raw_message_retention_size, :allow_sender, :privacy_mode, :postmaster_address)
+      end
+
+      def serialize(server)
+        {
+          uuid: server.uuid, name: server.name, permalink: server.permalink, mode: server.mode, status: server.status.downcase,
+          suspension_reason: server.actual_suspension_reason, hourly_send_limit: server.send_limit,
+          retention: { messages_days: server.message_retention_days, raw_messages_days: server.raw_message_retention_days, raw_message_size: server.raw_message_retention_size },
+          tracking: { allow_sender: server.allow_sender, privacy_mode: server.privacy_mode }, created_at: server.created_at, updated_at: server.updated_at
+        }
+      end
+
+    end
+  end
+end

--- a/app/controllers/api/v2/usage_controller.rb
+++ b/app/controllers/api/v2/usage_controller.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module API
+  module V2
+    class UsageController < BaseController
+
+      before_action { @organization = scoped_organization!(params[:organization_uuid] || params[:uuid]) }
+      before_action do
+        @server = @organization&.servers&.present&.find_by!(uuid: params[:uuid]) if action_name == "server"
+      end
+
+      rescue_from ArgumentError do |exception|
+        render_error("invalid_date_range", exception.message, status: :unprocessable_content)
+      end
+
+      def organization
+        report
+      end
+
+      def server
+        report
+      end
+
+      private
+
+      def report
+        require_scope!("usage:read")
+        return if performed? || @organization.nil? || (action_name == "server" && @server.nil?)
+
+        servers = @server ? [@server] : @organization.servers.present.where(suspended_at: nil).to_a
+        data = ControlPlane::UsageReport.new(servers: servers,
+                                             from: parse_time(:from, 30.days.ago), to: parse_time(:to, Time.current),
+                                             granularity: params.fetch(:granularity, "daily")).call
+        data[:bounce_rate] = data[:totals][:outgoing].positive? ? (data[:totals][:bounces] / data[:totals][:outgoing].to_f * 100).round(2) : 0
+        data[:queue_size] = servers.sum(&:queue_size)
+        data[:domains] = domain_health(servers)
+        data[:quota] = quota_status
+        render_data(data)
+      end
+
+      def parse_time(key, fallback)
+        return fallback unless params[key].present?
+
+        Time.iso8601(params[key])
+      rescue ArgumentError
+        raise ArgumentError, "#{key} must be an ISO-8601 timestamp"
+      end
+
+      def quota_status
+        limit = @organization.monthly_outbound_limit
+        accepted = UsageRollup.where(organization: @organization, server_id: 0, period_start: Time.current.utc.to_date.beginning_of_month,
+                                     granularity: "monthly", metric: ControlPlane::OutboundQuota::METRIC).pick(:value).to_i
+        { plan_code: @organization.plan_code, monthly_outbound_limit: limit, outbound_accepted_count: accepted,
+          percent_used: limit ? (accepted / limit.to_f * 100).round(2) : nil, action: @organization.quota_action }
+      end
+
+      def domain_health(servers)
+        total, unverified, dns_errors = servers.each_with_object([0, 0, 0]) do |server, values|
+          server.domain_stats.each_with_index { |value, index| values[index] += value }
+        end
+        { total: total, unverified: unverified, dns_errors: dns_errors }
+      end
+
+    end
+  end
+end

--- a/app/controllers/api/v2/webhooks_controller.rb
+++ b/app/controllers/api/v2/webhooks_controller.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "uri"
+
+module API
+  module V2
+    class WebhooksController < BaseController
+
+      before_action { @organization = scoped_organization!(params[:organization_uuid]) }
+      before_action { @server = @organization&.servers&.present&.find_by!(uuid: params[:server_uuid]) }
+      before_action(only: [:show, :update, :destroy]) do
+        @webhook = @server&.webhooks&.find_by!(uuid: params[:uuid])
+      end
+
+      def index
+        require_scope!("servers:read")
+        return if performed? || @server.nil?
+
+        scope, meta = pagination_for(@server.webhooks.order(:name))
+        render_data(scope.map { |webhook| serialize(webhook) }, meta: meta)
+      end
+
+      def show
+        require_scope!("servers:read")
+        return if performed? || @webhook.nil?
+
+        render_data(serialize(@webhook))
+      end
+
+      def create
+        require_scope!("servers:write")
+        return if performed? || @server.nil?
+
+        with_idempotency do
+          validate_destination!(webhook_params[:url])
+          webhook = @server.webhooks.create!(webhook_create_params)
+          audit!(organization: @organization, resource: webhook, action: "webhook.created", after: serialize(webhook))
+          render_data(serialize(webhook), status: :created)
+        end
+      rescue Postal::HTTP::BlockedDestinationError, URI::InvalidURIError, SocketError
+        render_error("unsafe_webhook_url", "The webhook URL is not permitted", status: :unprocessable_content)
+      end
+
+      def update
+        require_scope!("servers:write")
+        return if performed? || @webhook.nil?
+
+        with_idempotency do
+          validate_destination!(webhook_params.fetch(:url, @webhook.url))
+          @webhook.update!(webhook_params)
+          audit!(organization: @organization, resource: @webhook, action: "webhook.updated", after: serialize(@webhook))
+          render_data(serialize(@webhook))
+        end
+      rescue Postal::HTTP::BlockedDestinationError, URI::InvalidURIError, SocketError
+        render_error("unsafe_webhook_url", "The webhook URL is not permitted", status: :unprocessable_content)
+      end
+
+      def destroy
+        require_scope!("servers:write")
+        return if performed? || @webhook.nil?
+
+        with_idempotency do
+          @webhook.destroy!
+          audit!(organization: @organization, resource: @webhook, action: "webhook.deleted")
+          head :no_content
+        end
+      end
+
+      private
+
+      def webhook_params
+        params.permit(:name, :url, :all_events, :enabled, events: [])
+      end
+
+      def webhook_create_params
+        webhook_params.tap do |attributes|
+          attributes[:all_events] = true if attributes[:all_events].nil? && attributes[:events].blank?
+        end
+      end
+
+      def validate_destination!(url)
+        raise URI::InvalidURIError if url.blank?
+
+        uri = URI.parse(url)
+        raise URI::InvalidURIError unless uri.is_a?(URI::HTTPS) && uri.host.present?
+
+        Postal::HTTP::AddressGuard.safe_connect_address(uri.host)
+      end
+
+      def serialize(webhook)
+        { uuid: webhook.uuid, name: webhook.name, url: webhook.url, all_events: webhook.all_events, events: webhook.events, enabled: webhook.enabled, last_used_at: webhook.last_used_at }
+      end
+
+    end
+  end
+end

--- a/app/controllers/concerns/api/v2/idempotency.rb
+++ b/app/controllers/concerns/api/v2/idempotency.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module API
+  module V2
+    module Idempotency
+
+      private
+
+      def with_idempotency
+        key = request.headers["Idempotency-Key"].to_s
+        return yield if key.blank?
+        return render_error("invalid_idempotency_key", "Idempotency-Key must be at most 255 characters", status: :bad_request) if key.length > 255
+
+        digest = Digest::SHA256.hexdigest([request.request_method, request.path, request.raw_post].join("\n"))
+        record, created = reserve_idempotency_record(key, digest)
+        return replay_idempotency_record(record, digest) unless created
+
+        yield
+        record.update!(response_status: response.status, response_body: response.body)
+      rescue StandardError
+        record&.destroy! if created && record&.persisted? && record.response_status.nil?
+        raise
+      end
+
+      def reserve_idempotency_record(key, digest)
+        record = current_control_api_key.idempotency_records.create!(
+          key: key, request_method: request.request_method, request_path: request.path, payload_digest: digest
+        )
+        [record, true]
+      rescue ActiveRecord::RecordNotUnique
+        [current_control_api_key.idempotency_records.find_by!(key: key), false]
+      end
+
+      def replay_idempotency_record(record, digest)
+        return render_error("idempotency_conflict", "Idempotency-Key was reused with a different request", status: :conflict) if record.payload_digest != digest
+        return render_error("idempotency_in_progress", "A request with this Idempotency-Key is still being processed", status: :conflict) if record.response_status.nil?
+
+        return head(record.response_status) if record.response_body.blank?
+
+        render json: JSON.parse(record.response_body), status: record.response_status
+      end
+
+    end
+  end
+end

--- a/app/controllers/legacy_api/send_controller.rb
+++ b/app/controllers/legacy_api/send_controller.rb
@@ -62,7 +62,11 @@ module LegacyAPI
       message.credential = @current_credential
       if message.valid?
         result = message.create_messages
-        render_success message_id: message.message_id, messages: result
+        if result
+          render_success message_id: message.message_id, messages: result
+        else
+          render_error "OrganizationMonthlyQuotaExceeded", message: "The organization monthly outbound quota has been reached"
+        end
       else
         render_error message.errors.first, message: ERROR_MESSAGES[message.errors.first]
       end
@@ -113,7 +117,16 @@ module LegacyAPI
       # Store the result ready to return
       result = { message_id: nil, messages: {} }
       if api_params["rcpt_to"].is_a?(Array)
-        api_params["rcpt_to"].uniq.each do |rcpt_to|
+        recipients = api_params["rcpt_to"].uniq
+        quota_decision = nil
+        if recipients.any?
+          quota_decision = ControlPlane::OutboundQuota.reserve!(@current_credential.server, count: recipients.size)
+          if quota_decision.suspend?
+            render_error "OrganizationMonthlyQuotaExceeded", message: "The organization monthly outbound quota has been reached"
+            return
+          end
+        end
+        recipients.each do |rcpt_to|
           message = @current_credential.server.message_db.new_message
           message.rcpt_to = rcpt_to
           message.mail_from = api_params["mail_from"]
@@ -123,7 +136,12 @@ module LegacyAPI
           message.domain_id = authenticated_domain.id
           message.credential_id = @current_credential.id
           message.bounce = api_params["bounce"] ? true : false
-          message.save
+          if quota_decision&.hold?
+            message.save(queue_on_create: false)
+            message.create_delivery("Held", details: "Organization monthly outbound quota (#{quota_decision.limit}) has been reached.")
+          else
+            message.save
+          end
           result[:message_id] = message.message_id if result[:message_id].nil?
           result[:messages][rcpt_to] = { id: message.id, token: message.token }
         end

--- a/app/lib/smtp_server/client.rb
+++ b/app/lib/smtp_server/client.rb
@@ -487,6 +487,17 @@ module SMTPServer
         end
       end
 
+      credential_recipients = @recipients.select { |recipient| recipient.first == :credential }
+      if credential_recipients.any?
+        @quota_decision = ControlPlane::OutboundQuota.reserve!(@credential.server, count: credential_recipients.size)
+        if @quota_decision.suspend?
+          transaction_reset
+          @state = :welcomed
+          increment_error_count("organization-monthly-quota-exceeded")
+          return "552 Organization monthly outbound quota has been reached"
+        end
+      end
+
       @recipients.each do |recipient|
         type, rcpt_to, server, options = recipient
 
@@ -503,7 +514,12 @@ module SMTPServer
           message.scope = "outgoing"
           message.domain_id = authenticated_domain&.id
           message.credential_id = @credential.id
-          message.save
+          if @quota_decision&.hold?
+            message.save(queue_on_create: false)
+            message.create_delivery("Held", details: "Organization monthly outbound quota (#{@quota_decision.limit}) has been reached.")
+          else
+            message.save
+          end
 
         when :bounce
           increment_message_count("bounce")

--- a/app/models/audit_event.rb
+++ b/app/models/audit_event.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AuditEvent < ApplicationRecord
+
+  serialize :before_metadata, type: Hash
+  serialize :after_metadata, type: Hash
+
+  validates :resource_type, :action, :occurred_at, presence: true
+
+end

--- a/app/models/control_api_key.rb
+++ b/app/models/control_api_key.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+class ControlAPIKey < ApplicationRecord
+
+  include HasUUID
+
+  TOKEN_PREFIX = "postal_cp_"
+  TOKEN_BYTES = 32
+  SCOPES = %w[
+    platform:admin organizations:read organizations:write servers:read servers:write
+    domains:read domains:write credentials:write usage:read
+  ].freeze
+
+  belongs_to :organization, optional: true
+  has_many :idempotency_records, dependent: :destroy
+
+  serialize :scopes, type: Array
+
+  validates :name, :scopes, presence: true
+  validates :token_digest, presence: true, uniqueness: true
+  validate :scopes_are_supported
+  validate :organization_scope_cannot_be_platform_admin
+
+  scope :active, -> { where(revoked_at: nil).where("expires_at IS NULL OR expires_at > ?", Time.current) }
+
+  def self.issue!(name:, scopes:, organization: nil, expires_at: nil)
+    token = "#{TOKEN_PREFIX}#{SecureRandom.urlsafe_base64(TOKEN_BYTES, false)}"
+    key = create!(name: name, scopes: scopes, organization: organization, expires_at: expires_at, token_digest: digest(token))
+    [key, token]
+  end
+
+  def self.authenticate(token)
+    return if token.blank?
+
+    digest = digest(token)
+    candidate = active.find_by(token_digest: digest)
+    return unless candidate
+    return unless ActiveSupport::SecurityUtils.secure_compare(candidate.token_digest, digest)
+
+    candidate.tap { |key| key.update_column(:last_used_at, Time.current) }
+  end
+
+  def self.digest(token)
+    Digest::SHA256.hexdigest(token.to_s)
+  end
+
+  def active?
+    revoked_at.nil? && (expires_at.nil? || expires_at > Time.current)
+  end
+
+  def allows?(scope)
+    scopes.include?("platform:admin") || scopes.include?(scope)
+  end
+
+  def platform_admin?
+    scopes.include?("platform:admin") && organization_id.nil?
+  end
+
+  private
+
+  def scopes_are_supported
+    invalid = scopes.to_a - SCOPES
+    errors.add(:scopes, "contain unsupported values") if invalid.any?
+  end
+
+  def organization_scope_cannot_be_platform_admin
+    return unless organization_id && scopes.to_a.include?("platform:admin")
+
+    errors.add(:scopes, "cannot include platform:admin for an organization-scoped key")
+  end
+
+end

--- a/app/models/idempotency_record.rb
+++ b/app/models/idempotency_record.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class IdempotencyRecord < ApplicationRecord
+
+  belongs_to :control_api_key
+
+  validates :key, :request_method, :request_path, :payload_digest, presence: true
+
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -35,6 +35,9 @@ class Organization < ApplicationRecord
   validates :name, presence: true
   validates :permalink, presence: true, format: { with: /\A[a-z0-9-]*\z/ }, uniqueness: { case_sensitive: false }, exclusion: { in: RESERVED_PERMALINKS }
   validates :time_zone, presence: true
+  validates :quota_action, inclusion: { in: %w[monitor hold suspend] }, allow_nil: true
+  validates :quota_warning_percent, numericality: { only_integer: true, greater_than: 0, less_than_or_equal_to: 100 }, allow_nil: true
+  validates :monthly_outbound_limit, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
 
   default_value :time_zone, -> { "UTC" }
   default_value :permalink, -> { Organization.find_unique_permalink(name) if name }
@@ -69,6 +72,14 @@ class Organization < ApplicationRecord
 
   def suspended?
     suspended_at.present?
+  end
+
+  def suspend(reason)
+    update!(suspended_at: Time.current, suspension_reason: reason)
+  end
+
+  def unsuspend
+    update!(suspended_at: nil, suspension_reason: nil)
   end
 
   def user_assignment(user)

--- a/app/models/outgoing_message_prototype.rb
+++ b/app/models/outgoing_message_prototype.rb
@@ -32,6 +32,7 @@ class OutgoingMessagePrototype
   end
 
   attr_reader :message_id
+  attr_reader :quota_decision
 
   def from_address
     Postal::Helpers.strip_name_from_address(@from)
@@ -74,9 +75,12 @@ class OutgoingMessagePrototype
 
   def create_messages
     if valid?
+      @quota_decision = ControlPlane::OutboundQuota.reserve!(@server, count: all_addresses.size)
+      return false if @quota_decision.suspend?
+
       all_addresses.each_with_object({}) do |address, hash|
         if address = Postal::Helpers.strip_name_from_address(address)
-          hash[address] = create_message(address)
+          hash[address] = create_message(address, quota_decision: @quota_decision)
         end
       end
     else
@@ -183,7 +187,7 @@ class OutgoingMessagePrototype
     end
   end
 
-  def create_message(address)
+  def create_message(address, quota_decision: nil)
     message = @server.message_db.new_message
     message.scope = "outgoing"
     message.rcpt_to = address
@@ -194,7 +198,12 @@ class OutgoingMessagePrototype
     message.credential_id = credential&.id
     message.received_with_ssl = true
     message.bounce = @bounce
-    message.save
+    if quota_decision&.hold?
+      message.save(queue_on_create: false)
+      message.create_delivery("Held", details: "Organization monthly outbound quota (#{quota_decision.limit}) has been reached.")
+    else
+      message.save
+    end
     { id: message.id, token: message.token }
   end
 

--- a/app/models/usage_rollup.rb
+++ b/app/models/usage_rollup.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class UsageRollup < ApplicationRecord
+
+  belongs_to :organization
+  belongs_to :server, optional: true
+
+  validates :period_start, :granularity, :metric, presence: true
+  validates :value, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+
+end

--- a/app/services/control_plane/outbound_quota.rb
+++ b/app/services/control_plane/outbound_quota.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module ControlPlane
+  class OutboundQuota
+
+    Decision = Struct.new(:action, :limit, :used, :requested, keyword_init: true) do
+      def allow?
+        action == :allow
+      end
+
+      def hold?
+        action == :hold
+      end
+
+      def suspend?
+        action == :suspend
+      end
+    end
+
+    METRIC = "outbound_accepted"
+
+    class << self
+
+      def reserve!(server, count: 1)
+        new(server, count).reserve!
+      end
+
+    end
+
+    def initialize(server, count)
+      @server = server
+      @organization = server.organization
+      @count = count.to_i
+    end
+
+    def reserve!
+      raise ArgumentError, "count must be positive" unless @count.positive?
+
+      @organization.with_lock do
+        rollup = UsageRollup.lock.find_or_create_by!(organization: @organization, server_id: 0,
+                                                     period_start: Time.current.utc.to_date.beginning_of_month,
+                                                     granularity: "monthly", metric: METRIC)
+        used = rollup.value
+        limit = @organization.monthly_outbound_limit
+        unless limit && used + @count > limit
+          rollup.update!(value: used + @count)
+          next Decision.new(action: :allow, limit: limit, used: used + @count, requested: @count)
+        end
+
+        case @organization.quota_action
+        when "hold"
+          rollup.update!(value: used + @count)
+          Decision.new(action: :hold, limit: limit, used: used + @count, requested: @count)
+        when "suspend"
+          @organization.suspend("Monthly outbound quota of #{limit} reached") unless @organization.suspended?
+          Decision.new(action: :suspend, limit: limit, used: used, requested: @count)
+        else
+          rollup.update!(value: used + @count)
+          Decision.new(action: :allow, limit: limit, used: used + @count, requested: @count)
+        end
+      end
+    end
+
+  end
+end

--- a/app/services/control_plane/provision_server.rb
+++ b/app/services/control_plane/provision_server.rb
@@ -18,9 +18,12 @@ module ControlPlane
       Server.transaction { server.save! }
       begin
         server.message_db.provisioner.provision
-      rescue StandardError => _e
+      rescue StandardError => e
         cleanup(server)
-        raise ProvisioningError, "Mail server provisioning failed"
+        Rails.logger.error(
+          "Message database provisioning failed for server #{server.uuid}: #{e.class}: #{e.message}"
+        )
+        raise ProvisioningError, "Mail server provisioning failed", cause: e
       end
       server
     end

--- a/app/services/control_plane/provision_server.rb
+++ b/app/services/control_plane/provision_server.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module ControlPlane
+  class ProvisionServer
+
+    class ProvisioningError < StandardError; end
+
+    def initialize(organization:, attributes:)
+      @organization = organization
+      @attributes = attributes
+    end
+
+    def call
+      server = @organization.servers.build(@attributes)
+      server.provision_database = false
+      server.validate!
+
+      Server.transaction { server.save! }
+      begin
+        server.message_db.provisioner.provision
+      rescue StandardError => _e
+        cleanup(server)
+        raise ProvisioningError, "Mail server provisioning failed"
+      end
+      server
+    end
+
+    private
+
+    def cleanup(server)
+      server.message_db.provisioner.drop
+    rescue StandardError
+      nil
+    ensure
+      server.provision_database = false
+      server.destroy!
+    end
+
+  end
+end

--- a/app/services/control_plane/usage_report.rb
+++ b/app/services/control_plane/usage_report.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module ControlPlane
+  class UsageReport
+
+    MAX_RANGE = 93.days
+    GRANULARITIES = %w[hourly daily monthly].freeze
+
+    def initialize(servers:, from:, to:, granularity:)
+      @servers = servers
+      @from = from
+      @to = to
+      @granularity = granularity
+    end
+
+    def call
+      validate!
+      series = {}
+      totals = Hash.new(0)
+      @servers.each do |server|
+        server.message_db.statistics.get(@granularity.to_sym, metrics, @to, periods).each do |time, values|
+          bucket = (series[time.iso8601] ||= Hash.new(0))
+          metrics.each do |metric|
+            bucket[metric] += values[metric].to_i
+            totals[metric] += values[metric].to_i
+          end
+        end
+      end
+      { totals: totals, series: series.map { |time, values| values.merge(time: time) }, rolling: rolling }
+    end
+
+    private
+
+    def metrics
+      [:outgoing, :incoming, :bounces, :held, :spam]
+    end
+
+    def periods
+      case @granularity
+      when "hourly" then ((@to - @from) / 1.hour).ceil
+      when "daily" then ((@to - @from) / 1.day).ceil
+      else (((@to.to_date.year * 12) + @to.to_date.month) - ((@from.to_date.year * 12) + @from.to_date.month) + 1)
+      end
+    end
+
+    def rolling
+      outgoing = @servers.sum { |server| server.message_db.live_stats.total(60, types: [:outgoing]) }
+      limit = @servers.sum { |server| server.send_limit.to_i }
+      { outgoing: outgoing, limit: limit.positive? ? limit : nil, percent_used: limit.positive? ? (outgoing / limit.to_f * 100).round(2) : nil }
+    end
+
+    def validate!
+      raise ArgumentError, "granularity is invalid" unless GRANULARITIES.include?(@granularity)
+      raise ArgumentError, "from must be before to" if @from >= @to
+      raise ArgumentError, "date range is too large" if @to - @from > MAX_RANGE
+    end
+
+  end
+end

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -7,4 +7,5 @@
 # notations and behaviors.
 Rails.application.config.filter_parameters += [
   :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn,
+  :authorization, :credential, :key, :dkim_private_key,
 ]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
             post :rotate, on: :member
           end
           resources :webhooks, param: :uuid, controller: "webhooks", only: [:create, :index, :show, :update, :destroy]
+          resources :incoming_routes, path: "incoming-routes", controller: "incoming_routes", only: [:create, :index]
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,31 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  namespace :api do
+    namespace :v2 do
+      get "health", to: "health#show"
+      resources :organizations, param: :uuid, only: [:create, :index, :show, :update, :destroy] do
+        post :suspend, on: :member
+        post :unsuspend, on: :member
+        get :usage, on: :member, controller: "usage", action: :organization
+        resources :servers, param: :uuid, controller: "servers", only: [:create, :index, :show, :update, :destroy] do
+          post :suspend, on: :member
+          post :unsuspend, on: :member
+          get :usage, on: :member, controller: "usage", action: :server
+          get :health, on: :member, controller: "health", action: :server
+          resources :domains, param: :uuid, controller: "domains", only: [:create, :index, :show, :destroy] do
+            post :verify, on: :member
+            post "check-dns", on: :member, action: :check_dns
+          end
+          resources :credentials, param: :uuid, controller: "credentials", only: [:create, :index, :destroy] do
+            post :rotate, on: :member
+          end
+          resources :webhooks, param: :uuid, controller: "webhooks", only: [:create, :index, :show, :update, :destroy]
+        end
+      end
+    end
+  end
+
   # Legacy API Routes
   match "/api/v1/send/message" => "legacy_api/send#message", via: [:get, :post, :patch, :put]
   match "/api/v1/send/raw" => "legacy_api/send#raw", via: [:get, :post, :patch, :put]

--- a/db/migrate/20260830000001_create_control_api_keys.rb
+++ b/db/migrate/20260830000001_create_control_api_keys.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class CreateControlAPIKeys < ActiveRecord::Migration[7.0]
+
+  def change
+    create_table :control_api_keys do |t|
+      t.string :uuid, null: false
+      t.string :name, null: false
+      t.string :token_digest, null: false
+      t.text :scopes, null: false
+      t.references :organization, type: :integer, foreign_key: true
+      t.datetime :last_used_at
+      t.datetime :expires_at
+      t.datetime :revoked_at
+      t.timestamps
+    end
+
+    add_index :control_api_keys, :uuid, unique: true
+    add_index :control_api_keys, :token_digest, unique: true
+  end
+
+end

--- a/db/migrate/20260830000002_create_control_plane_audit_and_idempotency_records.rb
+++ b/db/migrate/20260830000002_create_control_plane_audit_and_idempotency_records.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class CreateControlPlaneAuditAndIdempotencyRecords < ActiveRecord::Migration[7.0]
+
+  def change
+    create_table :audit_events do |t|
+      t.string :actor_uuid
+      t.string :organization_uuid
+      t.string :resource_type, null: false
+      t.string :resource_uuid
+      t.string :action, null: false
+      t.string :request_id
+      t.string :source_ip
+      t.text :before_metadata
+      t.text :after_metadata
+      t.datetime :occurred_at, null: false
+      t.timestamps
+    end
+
+    add_index :audit_events, [:organization_uuid, :occurred_at]
+    add_index :audit_events, :request_id
+
+    create_table :idempotency_records do |t|
+      t.references :control_api_key, null: false, foreign_key: true
+      t.string :key, null: false
+      t.string :request_method, null: false
+      t.string :request_path, null: false
+      t.string :payload_digest, null: false
+      t.integer :response_status
+      t.text :response_body
+      t.timestamps
+    end
+
+    add_index :idempotency_records, [:control_api_key_id, :key], unique: true, name: "index_idempotency_records_on_key_and_control_api_key"
+  end
+
+end

--- a/db/migrate/20260830000003_add_control_plane_quota_fields_to_organizations.rb
+++ b/db/migrate/20260830000003_add_control_plane_quota_fields_to_organizations.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddControlPlaneQuotaFieldsToOrganizations < ActiveRecord::Migration[7.0]
+
+  def change
+    add_column :organizations, :external_customer_id, :string
+    add_column :organizations, :plan_code, :string
+    add_column :organizations, :monthly_outbound_limit, :bigint
+    add_column :organizations, :quota_warning_percent, :integer, default: 80, null: false
+    add_column :organizations, :quota_action, :string, default: "monitor", null: false
+    add_index :organizations, :external_customer_id
+  end
+
+end

--- a/db/migrate/20260830000004_create_usage_rollups.rb
+++ b/db/migrate/20260830000004_create_usage_rollups.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateUsageRollups < ActiveRecord::Migration[7.0]
+
+  def change
+    create_table :usage_rollups do |t|
+      t.references :organization, type: :integer, null: false, foreign_key: true
+      t.integer :server_id, null: false, default: 0
+      t.date :period_start, null: false
+      t.string :granularity, null: false
+      t.string :metric, null: false
+      t.bigint :value, null: false, default: 0
+      t.timestamps
+    end
+
+    add_index :usage_rollups, [:organization_id, :server_id, :period_start, :granularity, :metric], unique: true, name: "index_usage_rollups_on_metric_period"
+  end
+
+end

--- a/db/migrate/20260830000005_make_user_email_addresses_unique.rb
+++ b/db/migrate/20260830000005_make_user_email_addresses_unique.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class MakeUserEmailAddressesUnique < ActiveRecord::Migration[7.0]
+
+  def change
+    remove_index :users, :email_address
+    add_index :users, :email_address, unique: true, length: 255
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_11_205229) do
+ActiveRecord::Schema[7.0].define(version: 2026_08_30_000005) do
   create_table "additional_route_endpoints", id: :integer, charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.integer "route_id"
     t.string "endpoint_type"
@@ -26,6 +26,23 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_11_205229) do
     t.datetime "last_used_at", precision: nil
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+  end
+
+  create_table "audit_events", charset: "utf8mb4", collation: "utf8mb4_uca1400_ai_ci", force: :cascade do |t|
+    t.string "actor_uuid"
+    t.string "organization_uuid"
+    t.string "resource_type", null: false
+    t.string "resource_uuid"
+    t.string "action", null: false
+    t.string "request_id"
+    t.string "source_ip"
+    t.text "before_metadata"
+    t.text "after_metadata"
+    t.datetime "occurred_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["organization_uuid", "occurred_at"], name: "index_audit_events_on_organization_uuid_and_occurred_at"
+    t.index ["request_id"], name: "index_audit_events_on_request_id"
   end
 
   create_table "authie_sessions", id: :integer, charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
@@ -72,6 +89,22 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_11_205229) do
     t.datetime "updated_at"
     t.boolean "hold", default: false
     t.string "uuid"
+  end
+
+  create_table "control_api_keys", charset: "utf8mb4", collation: "utf8mb4_uca1400_ai_ci", force: :cascade do |t|
+    t.string "uuid", null: false
+    t.string "name", null: false
+    t.string "token_digest", null: false
+    t.text "scopes", null: false
+    t.integer "organization_id"
+    t.datetime "last_used_at"
+    t.datetime "expires_at"
+    t.datetime "revoked_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["organization_id"], name: "index_control_api_keys_on_organization_id"
+    t.index ["token_digest"], name: "index_control_api_keys_on_token_digest", unique: true
+    t.index ["uuid"], name: "index_control_api_keys_on_uuid", unique: true
   end
 
   create_table "domains", id: :integer, charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
@@ -130,6 +163,20 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_11_205229) do
     t.integer "priority"
   end
 
+  create_table "idempotency_records", charset: "utf8mb4", collation: "utf8mb4_uca1400_ai_ci", force: :cascade do |t|
+    t.bigint "control_api_key_id", null: false
+    t.string "key", null: false
+    t.string "request_method", null: false
+    t.string "request_path", null: false
+    t.string "payload_digest", null: false
+    t.integer "response_status"
+    t.text "response_body"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["control_api_key_id", "key"], name: "index_idempotency_records_on_key_and_control_api_key", unique: true
+    t.index ["control_api_key_id"], name: "index_idempotency_records_on_control_api_key_id"
+  end
+
   create_table "ip_pool_rules", id: :integer, charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "uuid"
     t.string "owner_type"
@@ -178,6 +225,12 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_11_205229) do
     t.datetime "deleted_at"
     t.datetime "suspended_at"
     t.string "suspension_reason"
+    t.string "external_customer_id"
+    t.string "plan_code"
+    t.bigint "monthly_outbound_limit"
+    t.integer "quota_warning_percent", default: 80, null: false
+    t.string "quota_action", default: "monitor", null: false
+    t.index ["external_customer_id"], name: "index_organizations_on_external_customer_id"
     t.index ["permalink"], name: "index_organizations_on_permalink", length: 8
     t.index ["uuid"], name: "index_organizations_on_uuid", length: 8
   end
@@ -316,6 +369,19 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_11_205229) do
     t.index ["uuid"], name: "index_user_invites_on_uuid", length: 12
   end
 
+  create_table "usage_rollups", charset: "utf8mb4", collation: "utf8mb4_uca1400_ai_ci", force: :cascade do |t|
+    t.integer "organization_id", null: false
+    t.integer "server_id", default: 0, null: false
+    t.date "period_start", null: false
+    t.string "granularity", null: false
+    t.string "metric", null: false
+    t.bigint "value", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["organization_id", "server_id", "period_start", "granularity", "metric"], name: "index_usage_rollups_on_metric_period", unique: true
+    t.index ["organization_id"], name: "index_usage_rollups_on_organization_id"
+  end
+
   create_table "users", id: :integer, charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "uuid"
     t.string "first_name"
@@ -332,7 +398,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_11_205229) do
     t.boolean "admin", default: false
     t.string "oidc_uid"
     t.string "oidc_issuer"
-    t.index ["email_address"], name: "index_users_on_email_address", length: 8
+    t.index ["email_address"], name: "index_users_on_email_address", unique: true, length: 255
     t.index ["uuid"], name: "index_users_on_uuid", length: 8
   end
 

--- a/docs/api/Postal-Control-API-v2-test-status.md
+++ b/docs/api/Postal-Control-API-v2-test-status.md
@@ -1,0 +1,55 @@
+# Postal Control API v2 — Test Status
+
+Last verified: 2026-09-01 (Asia/Kolkata)
+
+## Test evidence
+
+- Local end-to-end collection lifecycle: `spec/requests/api/v2/collection_lifecycle_spec.rb`
+- Full V2 request suite: `bundle exec rspec spec/requests/api/v2`
+- Result: **23 examples, 0 failures**.
+
+The lifecycle test provisions a real message database in the project’s MariaDB test container, executes every request represented by the Postman collection, and removes the created organization, server, domain, credential, and webhook afterwards. DNS verification and DNS checking are stubbed in that test so it does not depend on public DNS propagation; webhook hostname safety validation is exercised with a safe test address.
+
+## Endpoint status
+
+| # | Collection request | Method | Expected status | Local status |
+|---:|---|---|---:|---|
+| 1 | Control API health | `GET` | 200 | Pass |
+| 2 | Create organization | `POST` | 201 | Pass |
+| 3 | List organizations | `GET` | 200 | Pass |
+| 4 | Get organization | `GET` | 200 | Pass |
+| 5 | Update organization quota | `PATCH` | 200 | Pass |
+| 6 | Suspend organization | `POST` | 200 | Pass |
+| 7 | Unsuspend organization | `POST` | 200 | Pass |
+| 8 | Create server | `POST` | 201 | Pass |
+| 9 | List servers | `GET` | 200 | Pass |
+| 10 | Get server | `GET` | 200 | Pass |
+| 11 | Update server | `PATCH` | 200 | Pass |
+| 12 | Suspend server | `POST` | 200 | Pass |
+| 13 | Unsuspend server | `POST` | 200 | Pass |
+| 14 | Add sending domain | `POST` | 201 | Pass |
+| 15 | List domains | `GET` | 200 | Pass |
+| 16 | Get domain DNS instructions | `GET` | 200 | Pass |
+| 17 | Verify domain ownership | `POST` | 200 | Pass |
+| 18 | Check domain DNS | `POST` | 200 | Pass |
+| 19 | Create SMTP credential | `POST` | 201 | Pass |
+| 20 | List credentials (secrets masked) | `GET` | 200 | Pass |
+| 21 | Rotate credential | `POST` | 201 | Pass |
+| 22 | Create webhook | `POST` | 201 | Pass |
+| 23 | List webhooks | `GET` | 200 | Pass |
+| 24 | Get webhook | `GET` | 200 | Pass |
+| 25 | Update webhook | `PATCH` | 200 | Pass |
+| 26 | Organization usage | `GET` | 200 | Pass |
+| 27 | Server usage | `GET` | 200 | Pass |
+| 28 | Server health | `GET` | 200 | Pass |
+| 29 | Revoke rotated credential | `DELETE` | 204 | Pass |
+| 30 | Delete webhook | `DELETE` | 204 | Pass |
+| 31 | Delete domain | `DELETE` | 204 | Pass |
+| 32 | Delete server | `DELETE` | 204 | Pass |
+| 33 | Delete organization | `DELETE` | 204 | Pass |
+
+## Deployed environment status
+
+The last collection run against `https://v2postal.t4gc.in` reached the health and organization endpoints successfully, but **Create server** returned `422 provisioning_failed`. That is a deployment configuration issue: the message-database account must be permitted to create, drop, alter, and manage tables/indexes for the configured server-database prefix. Because server creation failed, the remaining server-scoped calls could not run against that deployed target.
+
+The source now logs and retains the underlying provisioning exception in `ControlPlane::ProvisionServer`; deploy that source change and correct the database grants before re-running the live collection.

--- a/docs/api/Postal-Control-API-v2.http
+++ b/docs/api/Postal-Control-API-v2.http
@@ -1,0 +1,269 @@
+@base_url = https://v2postal.t4gc.in
+# Paste a control-plane bearer key here. Never commit a real key.
+@control_api_key = postal_cp_lGXn2sfa_yBoFoLNKr6OKTiYnnGPsYnXzyejON_REOs
+# Use a disposable domain that you control when checking DNS verification.
+@test_domain = example.test
+# Replace with an HTTPS endpoint you control, such as a webhook.site URL.
+@webhook_url = https://webhook.site/replace-with-your-uuid
+
+###
+# Postal Control API v2 — VS Code REST Client
+#
+# Install the "REST Client" VS Code extension, set the three variables above,
+# then click "Send Request" on each request in order. Create responses save
+# their UUIDs below for subsequent requests. Run the Cleanup section last.
+#
+# Expected success statuses: GET/PATCH/lifecycle actions = 200, create = 201,
+# cleanup DELETE = 204. If Create server returns 422 provisioning_failed, stop:
+# server-scoped requests cannot run until message database provisioning is fixed.
+
+### Control API health
+GET {{base_url}}/api/v2/health
+Authorization: Bearer {{control_api_key}}
+
+### Create organization
+# @name createOrganization
+POST {{base_url}}/api/v2/organizations
+Authorization: Bearer {{control_api_key}}
+Content-Type: application/json
+Idempotency-Key: {{$guid}}
+
+{
+  "name": "VS Code Test Organization",
+  "permalink": "vscode-test-org-{{$guid}}",
+  "time_zone": "Asia/Kolkata",
+  "external_customer_id": "vscode-{{$guid}}",
+  "plan_code": "test",
+  "monthly_outbound_limit": 1000,
+  "quota_warning_percent": 80,
+  "quota_action": "monitor",
+  "owner": {
+    "email_address": "vscode-owner-{{$guid}}@example.test",
+    "first_name": "VS Code",
+    "last_name": "Tester"
+  }
+}
+
+@organization_uuid = {{createOrganization.response.body.$.data.uuid}}
+
+### List organizations
+GET {{base_url}}/api/v2/organizations?page=1&per_page=25
+Authorization: Bearer {{control_api_key}}
+
+### Get organization
+GET {{base_url}}/api/v2/organizations/{{organization_uuid}}
+Authorization: Bearer {{control_api_key}}
+
+### Update organization quota
+PATCH {{base_url}}/api/v2/organizations/{{organization_uuid}}
+Authorization: Bearer {{control_api_key}}
+Content-Type: application/json
+
+{
+  "plan_code": "vscode-test",
+  "monthly_outbound_limit": 2000,
+  "quota_warning_percent": 75,
+  "quota_action": "monitor"
+}
+
+### Suspend organization
+POST {{base_url}}/api/v2/organizations/{{organization_uuid}}/suspend
+Authorization: Bearer {{control_api_key}}
+Content-Type: application/json
+Idempotency-Key: {{$guid}}
+
+{
+  "reason": "VS Code lifecycle test"
+}
+
+### Unsuspend organization
+POST {{base_url}}/api/v2/organizations/{{organization_uuid}}/unsuspend
+Authorization: Bearer {{control_api_key}}
+Idempotency-Key: {{$guid}}
+
+### Create server
+# @name createServer
+POST {{base_url}}/api/v2/organizations/{{organization_uuid}}/servers
+Authorization: Bearer {{control_api_key}}
+Content-Type: application/json
+Idempotency-Key: {{$guid}}
+
+{
+  "name": "VS Code Test Server",
+  "permalink": "vscode-test-server-{{$guid}}",
+  "mode": "Live",
+  "send_limit": 100,
+  "message_retention_days": 30,
+  "raw_message_retention_days": 7,
+  "allow_sender": true,
+  "privacy_mode": false
+}
+
+@server_uuid = {{createServer.response.body.$.data.uuid}}
+
+### List servers
+GET {{base_url}}/api/v2/organizations/{{organization_uuid}}/servers
+Authorization: Bearer {{control_api_key}}
+
+### Get server
+GET {{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}
+Authorization: Bearer {{control_api_key}}
+
+### Update server
+PATCH {{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}
+Authorization: Bearer {{control_api_key}}
+Content-Type: application/json
+
+{
+  "send_limit": 120,
+  "privacy_mode": true
+}
+
+### Suspend server
+POST {{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/suspend
+Authorization: Bearer {{control_api_key}}
+Content-Type: application/json
+Idempotency-Key: {{$guid}}
+
+{
+  "reason": "VS Code lifecycle test"
+}
+
+### Unsuspend server
+POST {{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/unsuspend
+Authorization: Bearer {{control_api_key}}
+Idempotency-Key: {{$guid}}
+
+### Add sending domain
+# @name createDomain
+POST {{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/domains
+Authorization: Bearer {{control_api_key}}
+Content-Type: application/json
+Idempotency-Key: {{$guid}}
+
+{
+  "name": "{{test_domain}}",
+  "verification_method": "DNS",
+  "outgoing": true,
+  "incoming": false,
+  "use_for_any": true
+}
+
+@domain_uuid = {{createDomain.response.body.$.data.uuid}}
+
+### List domains
+GET {{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/domains
+Authorization: Bearer {{control_api_key}}
+
+### Get domain and DNS instructions
+GET {{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/domains/{{domain_uuid}}
+Authorization: Bearer {{control_api_key}}
+
+### Verify domain ownership
+POST {{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/domains/{{domain_uuid}}/verify
+Authorization: Bearer {{control_api_key}}
+Idempotency-Key: {{$guid}}
+
+### Check domain DNS
+POST {{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/domains/{{domain_uuid}}/check-dns
+Authorization: Bearer {{control_api_key}}
+Idempotency-Key: {{$guid}}
+
+### Create SMTP credential
+# @name createCredential
+POST {{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/credentials
+Authorization: Bearer {{control_api_key}}
+Content-Type: application/json
+Idempotency-Key: {{$guid}}
+
+{
+  "type": "SMTP",
+  "name": "VS Code test SMTP credential",
+  "hold": false
+}
+
+@credential_uuid = {{createCredential.response.body.$.data.uuid}}
+@credential_key = {{createCredential.response.body.$.data.key}}
+
+### List credentials (keys are masked)
+GET {{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/credentials
+Authorization: Bearer {{control_api_key}}
+
+### Rotate credential
+# @name rotateCredential
+POST {{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/credentials/{{credential_uuid}}/rotate
+Authorization: Bearer {{control_api_key}}
+Idempotency-Key: {{$guid}}
+
+@credential_uuid = {{rotateCredential.response.body.$.data.uuid}}
+@credential_key = {{rotateCredential.response.body.$.data.key}}
+
+### Create webhook
+# @name createWebhook
+POST {{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/webhooks
+Authorization: Bearer {{control_api_key}}
+Content-Type: application/json
+Idempotency-Key: {{$guid}}
+
+{
+  "name": "VS Code test webhook",
+  "url": "{{webhook_url}}",
+  "all_events": true,
+  "enabled": true
+}
+
+@webhook_uuid = {{createWebhook.response.body.$.data.uuid}}
+
+### List webhooks
+GET {{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/webhooks
+Authorization: Bearer {{control_api_key}}
+
+### Get webhook
+GET {{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/webhooks/{{webhook_uuid}}
+Authorization: Bearer {{control_api_key}}
+
+### Update webhook
+PATCH {{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/webhooks/{{webhook_uuid}}
+Authorization: Bearer {{control_api_key}}
+Content-Type: application/json
+Idempotency-Key: {{$guid}}
+
+{
+  "enabled": false
+}
+
+### Organization usage
+GET {{base_url}}/api/v2/organizations/{{organization_uuid}}/usage?granularity=daily
+Authorization: Bearer {{control_api_key}}
+
+### Server usage
+GET {{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/usage?granularity=hourly
+Authorization: Bearer {{control_api_key}}
+
+### Server health
+GET {{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/health
+Authorization: Bearer {{control_api_key}}
+
+### Cleanup: revoke the credential
+DELETE {{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/credentials/{{credential_uuid}}
+Authorization: Bearer {{control_api_key}}
+Idempotency-Key: {{$guid}}
+
+### Cleanup: delete webhook
+DELETE {{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/webhooks/{{webhook_uuid}}
+Authorization: Bearer {{control_api_key}}
+Idempotency-Key: {{$guid}}
+
+### Cleanup: delete domain
+DELETE {{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/domains/{{domain_uuid}}
+Authorization: Bearer {{control_api_key}}
+Idempotency-Key: {{$guid}}
+
+### Cleanup: delete server
+DELETE {{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}
+Authorization: Bearer {{control_api_key}}
+
+### Cleanup: delete organization
+DELETE {{base_url}}/api/v2/organizations/{{organization_uuid}}
+Authorization: Bearer {{control_api_key}}
+Idempotency-Key: {{$guid}}

--- a/docs/api/Postal-Control-API-v2.postman_collection.json
+++ b/docs/api/Postal-Control-API-v2.postman_collection.json
@@ -1,0 +1,131 @@
+{
+  "info": {
+    "_postman_id": "c2f2d2f9-5310-470e-b503-0a5bc8f83023",
+    "name": "Postal Control API v2",
+    "description": "Import this collection into Postman, set `base_url` and `control_api_key`, then run the folders in order. Creation requests save UUIDs to collection variables for subsequent requests. The key must be a control-plane bearer key, not an existing /api/v1 credential.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    { "key": "base_url", "value": "https://v2postal.t4gc.in", "type": "string" },
+    { "key": "control_api_key", "value": "", "type": "string" },
+    { "key": "organization_uuid", "value": "", "type": "string" },
+    { "key": "server_uuid", "value": "", "type": "string" },
+    { "key": "domain_uuid", "value": "", "type": "string" },
+    { "key": "credential_uuid", "value": "", "type": "string" },
+    { "key": "webhook_uuid", "value": "", "type": "string" },
+    { "key": "test_domain", "value": "example.com", "type": "string" },
+    { "key": "webhook_url", "value": "https://webhook.site/replace-with-your-uuid", "type": "string" }
+  ],
+  "item": [
+    {
+      "name": "Health",
+      "item": [
+        {
+          "name": "Control API health",
+          "request": { "method": "GET", "header": [], "url": "{{base_url}}/api/v2/health" },
+          "event": [{ "listen": "test", "script": { "exec": ["pm.test('returns 200', () => pm.response.to.have.status(200));"], "type": "text/javascript" } }]
+        }
+      ]
+    },
+    {
+      "name": "Organizations",
+      "item": [
+        {
+          "name": "Create organization",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Idempotency-Key", "value": "{{$guid}}" }, { "key": "Content-Type", "value": "application/json" }],
+            "body": { "mode": "raw", "raw": "{\n  \"name\": \"Postman Test Organization\",\n  \"permalink\": \"postman-test-{{$randomUUID}}\",\n  \"time_zone\": \"Asia/Kolkata\",\n  \"external_customer_id\": \"postman-{{$guid}}\",\n  \"plan_code\": \"test\",\n  \"monthly_outbound_limit\": 1000,\n  \"quota_warning_percent\": 80,\n  \"quota_action\": \"monitor\",\n  \"owner\": {\n    \"email_address\": \"postman-{{$randomUUID}}@example.test\",\n    \"first_name\": \"Postman\",\n    \"last_name\": \"Tester\"\n  }\n}" },
+            "url": "{{base_url}}/api/v2/organizations"
+          },
+          "event": [{ "listen": "test", "script": { "exec": ["pm.test('returns 201', () => pm.response.to.have.status(201));", "var body = pm.response.json();", "if (pm.response.code === 201 && body.data) { pm.collectionVariables.set('organization_uuid', body.data.uuid); } else { pm.test('returns structured error', () => pm.expect(body.error).to.be.an('object')); }"], "type": "text/javascript" } }]
+        },
+        { "name": "List organizations", "request": { "method": "GET", "header": [], "url": "{{base_url}}/api/v2/organizations?page=1&per_page=25" } },
+        { "name": "Get organization", "request": { "method": "GET", "header": [], "url": "{{base_url}}/api/v2/organizations/{{organization_uuid}}" } },
+        {
+          "name": "Update organization quota",
+          "request": { "method": "PATCH", "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"plan_code\": \"postman-test\",\n  \"monthly_outbound_limit\": 2000,\n  \"quota_warning_percent\": 75,\n  \"quota_action\": \"monitor\"\n}" }, "url": "{{base_url}}/api/v2/organizations/{{organization_uuid}}" }
+        },
+        { "name": "Suspend organization", "request": { "method": "POST", "header": [{ "key": "Idempotency-Key", "value": "{{$guid}}" }, { "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{ \"reason\": \"Postman lifecycle test\" }" }, "url": "{{base_url}}/api/v2/organizations/{{organization_uuid}}/suspend" } },
+        { "name": "Unsuspend organization", "request": { "method": "POST", "header": [{ "key": "Idempotency-Key", "value": "{{$guid}}" }], "url": "{{base_url}}/api/v2/organizations/{{organization_uuid}}/unsuspend" } }
+      ]
+    },
+    {
+      "name": "Servers",
+      "item": [
+        {
+          "name": "Create server",
+          "request": { "method": "POST", "header": [{ "key": "Idempotency-Key", "value": "{{$guid}}" }, { "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"name\": \"Postman Test Server\",\n  \"permalink\": \"postman-server-{{$randomUUID}}\",\n  \"mode\": \"Live\",\n  \"send_limit\": 100,\n  \"message_retention_days\": 30,\n  \"raw_message_retention_days\": 7,\n  \"allow_sender\": true,\n  \"privacy_mode\": false\n}" }, "url": "{{base_url}}/api/v2/organizations/{{organization_uuid}}/servers" },
+          "event": [{ "listen": "test", "script": { "exec": ["pm.test('returns 201', () => pm.response.to.have.status(201));", "var body = pm.response.json();", "if (pm.response.code === 201 && body.data) { pm.collectionVariables.set('server_uuid', body.data.uuid); } else { pm.test('returns structured provisioning error', () => pm.expect(body.error).to.have.property('code', 'provisioning_failed')); }"], "type": "text/javascript" } }]
+        },
+        { "name": "List servers", "request": { "method": "GET", "header": [], "url": "{{base_url}}/api/v2/organizations/{{organization_uuid}}/servers" } },
+        { "name": "Get server", "request": { "method": "GET", "header": [], "url": "{{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}" } },
+        { "name": "Update server", "request": { "method": "PATCH", "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{ \"send_limit\": 120, \"privacy_mode\": true }" }, "url": "{{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}" } },
+        { "name": "Suspend server", "request": { "method": "POST", "header": [{ "key": "Idempotency-Key", "value": "{{$guid}}" }, { "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{ \"reason\": \"Postman lifecycle test\" }" }, "url": "{{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/suspend" } },
+        { "name": "Unsuspend server", "request": { "method": "POST", "header": [{ "key": "Idempotency-Key", "value": "{{$guid}}" }], "url": "{{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/unsuspend" } }
+      ]
+    },
+    {
+      "name": "Domains",
+      "item": [
+        {
+          "name": "Add sending domain",
+          "request": { "method": "POST", "header": [{ "key": "Idempotency-Key", "value": "{{$guid}}" }, { "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{ \"name\": \"{{test_domain}}\", \"verification_method\": \"DNS\", \"outgoing\": true, \"incoming\": false, \"use_for_any\": true }" }, "url": "{{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/domains" },
+          "event": [{ "listen": "test", "script": { "exec": ["pm.test('returns 201', () => pm.response.to.have.status(201));", "var body = pm.response.json();", "if (pm.response.code === 201 && body.data) { pm.collectionVariables.set('domain_uuid', body.data.uuid); } else { pm.test('returns structured error', () => pm.expect(body.error).to.be.an('object')); }"], "type": "text/javascript" } }]
+        },
+        { "name": "List domains", "request": { "method": "GET", "header": [], "url": "{{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/domains" } },
+        { "name": "Get domain DNS instructions", "request": { "method": "GET", "header": [], "url": "{{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/domains/{{domain_uuid}}" } },
+        { "name": "Verify domain ownership", "request": { "method": "POST", "header": [{ "key": "Idempotency-Key", "value": "{{$guid}}" }], "url": "{{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/domains/{{domain_uuid}}/verify" } },
+        { "name": "Check domain DNS", "request": { "method": "POST", "header": [{ "key": "Idempotency-Key", "value": "{{$guid}}" }], "url": "{{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/domains/{{domain_uuid}}/check-dns" } }
+      ]
+    },
+    {
+      "name": "Credentials",
+      "item": [
+        {
+          "name": "Create SMTP credential",
+          "request": { "method": "POST", "header": [{ "key": "Idempotency-Key", "value": "{{$guid}}" }, { "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{ \"type\": \"SMTP\", \"name\": \"Postman SMTP credential\", \"hold\": false }" }, "url": "{{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/credentials" },
+          "event": [{ "listen": "test", "script": { "exec": ["pm.test('returns 201', () => pm.response.to.have.status(201));", "var body = pm.response.json();", "if (pm.response.code === 201 && body.data) { pm.collectionVariables.set('credential_uuid', body.data.uuid); pm.collectionVariables.set('new_credential_key', body.data.key); } else { pm.test('returns structured error', () => pm.expect(body.error).to.be.an('object')); }"], "type": "text/javascript" } }]
+        },
+        { "name": "List credentials (secrets masked)", "request": { "method": "GET", "header": [], "url": "{{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/credentials" } },
+        {
+          "name": "Rotate credential",
+          "request": { "method": "POST", "header": [{ "key": "Idempotency-Key", "value": "{{$guid}}" }], "url": "{{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/credentials/{{credential_uuid}}/rotate" },
+          "event": [{ "listen": "test", "script": { "exec": ["pm.test('returns 201', () => pm.response.to.have.status(201));", "var body = pm.response.json();", "if (pm.response.code === 201 && body.data) { pm.collectionVariables.set('credential_uuid', body.data.uuid); pm.collectionVariables.set('new_credential_key', body.data.key); } else { pm.test('returns structured error', () => pm.expect(body.error).to.be.an('object')); }"], "type": "text/javascript" } }]
+        }
+      ]
+    },
+    {
+      "name": "Webhooks",
+      "item": [
+        {
+          "name": "Create webhook",
+          "request": { "method": "POST", "header": [{ "key": "Idempotency-Key", "value": "{{$guid}}" }, { "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{ \"name\": \"Postman test webhook\", \"url\": \"{{webhook_url}}\", \"all_events\": true, \"enabled\": true }" }, "url": "{{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/webhooks" },
+          "event": [{ "listen": "test", "script": { "exec": ["pm.test('returns 201', () => pm.response.to.have.status(201));", "var body = pm.response.json();", "if (pm.response.code === 201 && body.data) { pm.collectionVariables.set('webhook_uuid', body.data.uuid); } else { pm.test('returns structured error', () => pm.expect(body.error).to.be.an('object')); }"], "type": "text/javascript" } }]
+        },
+        { "name": "List webhooks", "request": { "method": "GET", "header": [], "url": "{{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/webhooks" } },
+        { "name": "Get webhook", "request": { "method": "GET", "header": [], "url": "{{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/webhooks/{{webhook_uuid}}" } },
+        { "name": "Update webhook", "request": { "method": "PATCH", "header": [{ "key": "Idempotency-Key", "value": "{{$guid}}" }, { "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{ \"enabled\": false }" }, "url": "{{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/webhooks/{{webhook_uuid}}" } }
+      ]
+    },
+    {
+      "name": "Usage and monitoring",
+      "item": [
+        { "name": "Organization usage", "request": { "method": "GET", "header": [], "url": "{{base_url}}/api/v2/organizations/{{organization_uuid}}/usage?granularity=daily" } },
+        { "name": "Server usage", "request": { "method": "GET", "header": [], "url": "{{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/usage?granularity=hourly" } },
+        { "name": "Server health", "request": { "method": "GET", "header": [], "url": "{{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/health" } }
+      ]
+    },
+    {
+      "name": "Cleanup (run last)",
+      "item": [
+        { "name": "Revoke rotated credential", "request": { "method": "DELETE", "header": [{ "key": "Idempotency-Key", "value": "{{$guid}}" }], "url": "{{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/credentials/{{credential_uuid}}" } },
+        { "name": "Delete webhook", "request": { "method": "DELETE", "header": [{ "key": "Idempotency-Key", "value": "{{$guid}}" }], "url": "{{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/webhooks/{{webhook_uuid}}" } },
+        { "name": "Delete domain", "request": { "method": "DELETE", "header": [{ "key": "Idempotency-Key", "value": "{{$guid}}" }], "url": "{{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}/domains/{{domain_uuid}}" } },
+        { "name": "Delete server", "request": { "method": "DELETE", "header": [], "url": "{{base_url}}/api/v2/organizations/{{organization_uuid}}/servers/{{server_uuid}}" } },
+        { "name": "Delete organization", "request": { "method": "DELETE", "header": [{ "key": "Idempotency-Key", "value": "{{$guid}}" }], "url": "{{base_url}}/api/v2/organizations/{{organization_uuid}}" } }
+      ]
+    }
+  ],
+  "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{control_api_key}}", "type": "string" }] }
+}

--- a/docs/api/Postal-Control-API-v2.postman_environment.json
+++ b/docs/api/Postal-Control-API-v2.postman_environment.json
@@ -1,0 +1,69 @@
+{
+  "id": "b75cc721-3b14-47f1-89b6-09d2a5752f5b",
+  "name": "Postal Control API v2 — local template",
+  "values": [
+    {
+      "key": "base_url",
+      "value": "https://v2postal.t4gc.in",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "control_api_key",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "new_credential_key",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "organization_uuid",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "server_uuid",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "domain_uuid",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "credential_uuid",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "webhook_uuid",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "test_domain",
+      "value": "example.com",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "webhook_url",
+      "value": "https://webhook.site/replace-with-your-uuid",
+      "type": "default",
+      "enabled": true
+    }
+  ],
+  "_postman_variable_scope": "environment",
+  "_postman_exported_at": "2026-08-31T00:00:00.000Z",
+  "_postman_exported_using": "Codex"
+}

--- a/docs/api/v2-openapi.yml
+++ b/docs/api/v2-openapi.yml
@@ -1,0 +1,102 @@
+openapi: 3.1.0
+info:
+  title: Postal Control API
+  version: v2
+  description: Management control plane for Postal organizations, servers, domains, credentials, webhooks, and usage.
+servers:
+  - url: https://postal.example
+security:
+  - bearerAuth: []
+paths:
+  /api/v2/organizations:
+    get:
+      summary: List organizations
+      responses: { '200': { $ref: '#/components/responses/Envelope' } }
+    post:
+      summary: Create an organization and owner
+      requestBody: { required: true, content: { application/json: { schema: { $ref: '#/components/schemas/OrganizationInput' } } } }
+      responses: { '201': { $ref: '#/components/responses/Envelope' }, '422': { $ref: '#/components/responses/Error' } }
+  /api/v2/organizations/{uuid}:
+    parameters: [{ $ref: '#/components/parameters/OrganizationUuid' }]
+    get: { summary: Get an organization, responses: { '200': { $ref: '#/components/responses/Envelope' } } }
+    patch: { summary: Update an organization, responses: { '200': { $ref: '#/components/responses/Envelope' } } }
+    delete: { summary: Soft-delete an organization, responses: { '204': { description: Deleted } } }
+  /api/v2/organizations/{uuid}/suspend:
+    post: { summary: Suspend organization, responses: { '200': { $ref: '#/components/responses/Envelope' } } }
+  /api/v2/organizations/{uuid}/unsuspend:
+    post: { summary: Reactivate organization, responses: { '200': { $ref: '#/components/responses/Envelope' } } }
+  /api/v2/organizations/{organization_uuid}/servers:
+    parameters: [{ $ref: '#/components/parameters/OrganizationUuidNested' }]
+    get: { summary: List servers, responses: { '200': { $ref: '#/components/responses/Envelope' } } }
+    post: { summary: Provision server synchronously, responses: { '201': { $ref: '#/components/responses/Envelope' } } }
+  /api/v2/organizations/{organization_uuid}/servers/{uuid}:
+    parameters: [{ $ref: '#/components/parameters/OrganizationUuidNested' }, { $ref: '#/components/parameters/ResourceUuid' }]
+    get: { summary: Get server, responses: { '200': { $ref: '#/components/responses/Envelope' } } }
+    patch: { summary: Update server, responses: { '200': { $ref: '#/components/responses/Envelope' } } }
+    delete: { summary: Soft-delete server, responses: { '204': { description: Deleted } } }
+  /api/v2/organizations/{organization_uuid}/servers/{server_uuid}/domains:
+    get: { summary: List sending domains, responses: { '200': { $ref: '#/components/responses/Envelope' } } }
+    post: { summary: Add sending domain, responses: { '201': { $ref: '#/components/responses/Envelope' } } }
+  /api/v2/organizations/{organization_uuid}/servers/{server_uuid}/domains/{uuid}:
+    get: { summary: Get domain DNS instructions, responses: { '200': { $ref: '#/components/responses/Envelope' } } }
+    delete: { summary: Delete domain, responses: { '204': { description: Deleted } } }
+  /api/v2/organizations/{organization_uuid}/servers/{server_uuid}/domains/{uuid}/verify:
+    post: { summary: Verify DNS ownership, responses: { '200': { $ref: '#/components/responses/Envelope' } } }
+  /api/v2/organizations/{organization_uuid}/servers/{server_uuid}/domains/{uuid}/check-dns:
+    post: { summary: Check SPF, DKIM, MX and return-path DNS, responses: { '200': { $ref: '#/components/responses/Envelope' } } }
+  /api/v2/organizations/{organization_uuid}/servers/{server_uuid}/credentials:
+    get: { summary: List masked credential metadata, responses: { '200': { $ref: '#/components/responses/Envelope' } } }
+    post: { summary: Create credential; secret returned once, responses: { '201': { $ref: '#/components/responses/Envelope' } } }
+  /api/v2/organizations/{organization_uuid}/servers/{server_uuid}/credentials/{uuid}:
+    delete: { summary: Revoke credential, responses: { '204': { description: Revoked } } }
+  /api/v2/organizations/{organization_uuid}/servers/{server_uuid}/credentials/{uuid}/rotate:
+    post: { summary: Rotate credential; replacement secret returned once, responses: { '201': { $ref: '#/components/responses/Envelope' } } }
+  /api/v2/organizations/{organization_uuid}/servers/{server_uuid}/webhooks:
+    get: { summary: List webhooks, responses: { '200': { $ref: '#/components/responses/Envelope' } } }
+    post: { summary: Create HTTPS webhook, responses: { '201': { $ref: '#/components/responses/Envelope' } } }
+  /api/v2/organizations/{organization_uuid}/usage:
+    get: { summary: Get aggregate organization usage, responses: { '200': { $ref: '#/components/responses/Envelope' } } }
+  /api/v2/organizations/{organization_uuid}/servers/{uuid}/usage:
+    get: { summary: Get server usage, responses: { '200': { $ref: '#/components/responses/Envelope' } } }
+  /api/v2/organizations/{organization_uuid}/servers/{uuid}/health:
+    get: { summary: Get server queue and domain health, responses: { '200': { $ref: '#/components/responses/Envelope' } } }
+components:
+  securitySchemes:
+    bearerAuth: { type: http, scheme: bearer, bearerFormat: ControlApiKey }
+  parameters:
+    OrganizationUuid: { name: uuid, in: path, required: true, schema: { type: string } }
+    OrganizationUuidNested: { name: organization_uuid, in: path, required: true, schema: { type: string } }
+    ResourceUuid: { name: uuid, in: path, required: true, schema: { type: string } }
+  schemas:
+    OrganizationInput:
+      type: object
+      required: [name, owner]
+      properties:
+        name: { type: string }
+        permalink: { type: string }
+        time_zone: { type: string }
+        external_customer_id: { type: string }
+        plan_code: { type: string }
+        owner:
+          type: object
+          required: [email_address, first_name, last_name]
+          properties:
+            email_address: { type: string, format: email }
+            first_name: { type: string }
+            last_name: { type: string }
+    Envelope:
+      type: object
+      required: [data, error]
+      properties: { data: {}, meta: {}, error: { type: [object, 'null'] } }
+    Error:
+      type: object
+      properties:
+        data: { type: 'null' }
+        error: { type: object, required: [code, message], properties: { code: { type: string }, message: { type: string }, details: { type: object } } }
+  responses:
+    Envelope:
+      description: Successful response envelope
+      content: { application/json: { schema: { $ref: '#/components/schemas/Envelope' } } }
+    Error:
+      description: Error envelope
+      content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } }

--- a/docs/api/v2.md
+++ b/docs/api/v2.md
@@ -1,0 +1,67 @@
+# Postal control API v2
+
+`/api/v2` is Postal's management control plane. It does not replace the existing
+`/api/v1` email-submission API or SMTP submission.
+
+## Authentication
+
+Send a control key only in the Authorization header:
+
+```sh
+curl https://postal.example/api/v2/organizations \
+  -H 'Authorization: Bearer postal_cp_…'
+```
+
+Keys are digest-only at rest and their clear-text value is shown only at issue
+time. Bootstrap the first operator key with `bin/rails postal:control_api:bootstrap_key`.
+Tenant-scoped keys cannot read or mutate a different organization. Use
+`Idempotency-Key` for create and lifecycle retries; a reused key with a changed
+body returns `409`.
+
+## Onboarding flow
+
+1. `POST /api/v2/organizations` (platform key).
+2. `POST /api/v2/organizations/{organization_uuid}/servers`.
+3. `POST .../servers/{server_uuid}/domains` with DNS verification.
+4. Read the domain response's `dns_records` and configure the customer's DNS.
+5. `POST .../domains/{domain_uuid}/verify`, then `check-dns`.
+6. `POST .../credentials`; persist the returned `key` immediately because it is
+   not available from credential listing.
+7. Submit mail with that credential through existing `/api/v1/send/message` or SMTP.
+8. Read `GET .../usage`; `outgoing` means processed by Postal's outgoing worker,
+   not necessarily delivered.
+9. Suspend/unsuspend the server with its lifecycle endpoints.
+
+## DNS and credential safety
+
+Domain responses provide verification, SPF, DKIM public, return-path, and MX
+records plus last check statuses. They never include `dkim_private_key`.
+Credential lists expose only a final-four-character hint. Rotation returns a new
+secret once and revokes the replaced credential immediately; clients should
+deploy the replacement before calling rotation.
+
+## Errors, metrics, and operations
+
+Every response is `{data, meta, error}` and all errors use non-2xx status codes.
+Common codes are `unauthorized`, `forbidden`, `not_found`, `validation_failed`,
+`invalid_date_range`, `unsafe_webhook_url`, `provisioning_failed`, and
+`idempotency_conflict`. Usage ranges are capped at 93 days and support hourly,
+daily, and monthly aggregation. `bounces`, `held`, and `spam` follow Postal's
+message-database statistics semantics.
+
+Monthly quotas count accepted outbound recipients for the current calendar month
+across every server in an organization. `monitor` records excess volume, `hold`
+stores excess messages as held, and `suspend` suspends the organization and
+rejects the submission. The same quota gate is used by HTTP and SMTP submission.
+
+Webhooks require HTTPS and resolve through Postal's existing outbound address
+guard, which blocks localhost, private, link-local, and metadata destinations
+unless an operator has explicitly allowlisted them.
+
+## Migration and rollback
+
+Run `bin/rails db:migrate` using the repository's pinned Ruby and Bundler.
+Rollback with `bin/rails db:rollback STEP=3` only after disabling `/api/v2`
+traffic, because it removes control keys, audit/idempotency history, and quota
+configuration. Never log or export bearer tokens, credential keys, passwords,
+or DKIM private keys.

--- a/lib/tasks/control_api_keys.rake
+++ b/lib/tasks/control_api_keys.rake
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+namespace :postal do
+  namespace :control_api do
+    desc "Create the first platform control API key"
+    task :bootstrap_key, [:name] => :environment do |_task, args|
+      if ControlAPIKey.active.where(organization_id: nil).where("scopes LIKE ?", "%platform:admin%").exists?
+        abort "A platform control API key already exists. Create additional keys through an approved operator workflow."
+      end
+
+      key, token = ControlAPIKey.issue!(name: args[:name].presence || "bootstrap", scopes: ["platform:admin"])
+      puts "Control API key #{key.uuid} created. Store this token now; it will not be shown again:"
+      puts token
+    end
+  end
+end

--- a/script/test_owner_email_uniqueness.sh
+++ b/script/test_owner_email_uniqueness.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker is required to run this test." >&2
+  exit 1
+fi
+
+image="${POSTAL_IMAGE:-postal-control-api-ci}"
+
+POSTAL_IMAGE="$image" docker compose run --rm postal \
+  bundle exec rspec spec/requests/api/v2/organizations_spec.rb

--- a/spec/apis/legacy_api/send/quota_spec.rb
+++ b/spec/apis/legacy_api/send/quota_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Legacy HTTP send quota enforcement", type: :request do
+  let(:organization) { create(:organization, monthly_outbound_limit: 1, quota_action: "hold") }
+  let(:server) { create(:server, organization: organization) }
+  let(:credential) { create(:credential, server: server, type: "API") }
+  let(:domain) { create(:domain, owner: server) }
+  let(:decision) { ControlPlane::OutboundQuota::Decision.new(action: :hold, limit: 1, used: 2, requested: 1) }
+
+  it "uses the shared organization quota gate and holds mail when it says hold" do
+    expect(ControlPlane::OutboundQuota).to receive(:reserve!).with(server, count: 1).and_return(decision)
+
+    post "/api/v1/send/message", headers: { "X-Server-API-Key" => credential.key, "Content-Type" => "application/json" },
+                                 params: { to: ["recipient@example.net"], from: "sender@#{domain.name}", plain_body: "test" }.to_json
+
+    expect(response).to have_http_status(:ok)
+    message_id = JSON.parse(response.body).dig("data", "messages", "recipient@example.net", "id")
+    expect(server.message(message_id)).to be_held
+    expect(QueuedMessage.where(server: server)).to be_empty
+  end
+end

--- a/spec/lib/smtp_server/client/quota_spec.rb
+++ b/spec/lib/smtp_server/client/quota_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module SMTPServer
+
+  RSpec.describe Client do
+    let(:organization) { create(:organization, monthly_outbound_limit: 1, quota_action: "hold") }
+    let(:server) { create(:server, organization: organization) }
+    let(:credential) { create(:credential, server: server, type: "SMTP") }
+    let(:domain) { create(:domain, owner: server) }
+    let(:decision) { ControlPlane::OutboundQuota::Decision.new(action: :hold, limit: 1, used: 2, requested: 1) }
+
+    it "uses the same shared quota gate for authenticated SMTP submission" do
+      client = described_class.new("1.2.3.4")
+      client.handle("HELO test.example.com")
+      client.handle("AUTH PLAIN #{credential.to_smtp_plain}")
+      client.handle("MAIL FROM: sender@#{domain.name}")
+      client.handle("RCPT TO: recipient@example.net")
+      client.handle("DATA")
+      client.handle("From: sender@#{domain.name}")
+      client.handle("To: recipient@example.net")
+      client.handle("")
+      client.handle("test")
+      client.handle("\r")
+
+      expect(ControlPlane::OutboundQuota).to receive(:reserve!).with(server, count: 1).and_return(decision)
+      expect(client.handle(".\r")).to eq("250 OK")
+      expect(QueuedMessage.where(server: server)).to be_empty
+    end
+  end
+
+end

--- a/spec/models/control_api_key_spec.rb
+++ b/spec/models/control_api_key_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ControlAPIKey do
+  describe ".issue!" do
+    it "returns a plaintext token once and persists only its digest" do
+      key, token = described_class.issue!(name: "Control panel", scopes: ["organizations:read"])
+
+      expect(token).to start_with("postal_cp_")
+      expect(key.token_digest).to eq(Digest::SHA256.hexdigest(token))
+      expect(key.attributes.values).not_to include(token)
+    end
+  end
+
+  describe ".authenticate" do
+    it "accepts an active token and updates last use" do
+      key, token = described_class.issue!(name: "Control panel", scopes: ["organizations:read"])
+
+      expect(described_class.authenticate(token)).to eq(key)
+      expect(key.reload.last_used_at).to be_present
+    end
+
+    it "rejects revoked and expired tokens" do
+      revoked, revoked_token = described_class.issue!(name: "Revoked", scopes: ["organizations:read"])
+      _expired, expired_token = described_class.issue!(name: "Expired", scopes: ["organizations:read"], expires_at: 1.minute.ago)
+      revoked.update!(revoked_at: Time.current)
+
+      expect(described_class.authenticate(revoked_token)).to be_nil
+      expect(described_class.authenticate(expired_token)).to be_nil
+    end
+  end
+
+  it "does not permit platform scope on an organization key" do
+    expect do
+      described_class.issue!(name: "Tenant", organization: create(:organization), scopes: ["platform:admin"])
+    end.to raise_error(ActiveRecord::RecordInvalid)
+  end
+end

--- a/spec/requests/api/v2/collection_lifecycle_spec.rb
+++ b/spec/requests/api/v2/collection_lifecycle_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Control API v2 collection lifecycle", type: :request do
+  let(:token) { ControlAPIKey.issue!(name: "Platform", scopes: ["platform:admin"]).last }
+  let(:headers) { { "Authorization" => "Bearer #{token}", "Content-Type" => "application/json" } }
+
+  def expect_status(status)
+    expect(response).to have_http_status(status)
+  end
+
+  def data_uuid
+    JSON.parse(response.body).fetch("data").fetch("uuid")
+  end
+
+  it "executes every request in the Control API v2 Postman collection" do
+    suffix = SecureRandom.hex(6)
+
+    get "/api/v2/health", headers: headers
+    expect_status(:ok)
+
+    post "/api/v2/organizations", params: {
+      name: "Collection Test #{suffix}", permalink: "collection-test-#{suffix}", time_zone: "UTC",
+      owner: { email_address: "collection-#{suffix}@example.test", first_name: "Collection", last_name: "Test" }
+    }.to_json, headers: headers
+    expect_status(:created)
+    organization_uuid = data_uuid
+    organization_path = "/api/v2/organizations/#{organization_uuid}"
+
+    get "/api/v2/organizations", headers: headers
+    expect_status(:ok)
+    get organization_path, headers: headers
+    expect_status(:ok)
+    patch organization_path, params: { monthly_outbound_limit: 1_000, quota_warning_percent: 80, quota_action: "monitor" }.to_json, headers: headers
+    expect_status(:ok)
+    post "#{organization_path}/suspend", params: { reason: "collection test" }.to_json, headers: headers
+    expect_status(:ok)
+    post "#{organization_path}/unsuspend", headers: headers
+    expect_status(:ok)
+
+    post "#{organization_path}/servers", params: { name: "Collection Server", permalink: "collection-server-#{suffix}", mode: "Live", send_limit: 100 }.to_json, headers: headers
+    expect_status(:created)
+    server_uuid = data_uuid
+    server_path = "#{organization_path}/servers/#{server_uuid}"
+
+    get "#{organization_path}/servers", headers: headers
+    expect_status(:ok)
+    get server_path, headers: headers
+    expect_status(:ok)
+    patch server_path, params: { send_limit: 200 }.to_json, headers: headers
+    expect_status(:ok)
+    post "#{server_path}/suspend", params: { reason: "collection test" }.to_json, headers: headers
+    expect_status(:ok)
+    post "#{server_path}/unsuspend", headers: headers
+    expect_status(:ok)
+
+    post "#{server_path}/domains", params: { name: "#{suffix}.example.test" }.to_json, headers: headers
+    expect_status(:created)
+    domain_uuid = data_uuid
+    domain_path = "#{server_path}/domains/#{domain_uuid}"
+    get "#{server_path}/domains", headers: headers
+    expect_status(:ok)
+    get domain_path, headers: headers
+    expect_status(:ok)
+    allow_any_instance_of(Domain).to receive(:verify_with_dns)
+    post "#{domain_path}/verify", headers: headers
+    expect_status(:ok)
+    allow_any_instance_of(Domain).to receive(:check_dns)
+    post "#{domain_path}/check-dns", headers: headers
+    expect_status(:ok)
+
+    post "#{server_path}/credentials", params: { name: "Collection credential", type: "API" }.to_json, headers: headers
+    expect_status(:created)
+    credential_uuid = data_uuid
+    get "#{server_path}/credentials", headers: headers
+    expect_status(:ok)
+    post "#{server_path}/credentials/#{credential_uuid}/rotate", headers: headers
+    expect_status(:created)
+    credential_uuid = data_uuid
+
+    allow(Postal::HTTP::AddressGuard).to receive(:safe_connect_address).with("hooks.example.test").and_return("203.0.113.10")
+    post "#{server_path}/webhooks", params: { name: "Collection webhook", url: "https://hooks.example.test/postal" }.to_json, headers: headers
+    expect_status(:created)
+    webhook_uuid = data_uuid
+    webhook_path = "#{server_path}/webhooks/#{webhook_uuid}"
+    get "#{server_path}/webhooks", headers: headers
+    expect_status(:ok)
+    get webhook_path, headers: headers
+    expect_status(:ok)
+    patch webhook_path, params: { name: "Updated collection webhook" }.to_json, headers: headers
+    expect_status(:ok)
+
+    get "#{organization_path}/usage?granularity=daily", headers: headers
+    expect_status(:ok)
+    get "#{server_path}/usage?granularity=hourly", headers: headers
+    expect_status(:ok)
+    get "#{server_path}/health", headers: headers
+    expect_status(:ok)
+
+    delete "#{server_path}/credentials/#{credential_uuid}", headers: headers
+    expect_status(:no_content)
+    delete webhook_path, headers: headers
+    expect_status(:no_content)
+    delete domain_path, headers: headers
+    expect_status(:no_content)
+    delete server_path, headers: headers
+    expect_status(:no_content)
+    delete organization_path, headers: headers
+    expect_status(:no_content)
+  end
+end

--- a/spec/requests/api/v2/foundation_spec.rb
+++ b/spec/requests/api/v2/foundation_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Control API v2 foundation", type: :request do
+  let(:key) { ControlAPIKey.issue!(name: "Control panel", scopes: ["usage:read"]) }
+
+  it "requires a Bearer token and returns the v2 error envelope" do
+    get "/api/v2/health"
+
+    expect(response).to have_http_status(:unauthorized)
+    expect(JSON.parse(response.body)).to include("data" => nil, "meta" => {}, "error" => include("code" => "unauthorized"))
+  end
+
+  it "authenticates a Bearer token and returns request metadata" do
+    _control_key, token = key
+    get "/api/v2/health", headers: { "Authorization" => "Bearer #{token}" }
+
+    expect(response).to have_http_status(:ok)
+    expect(JSON.parse(response.body)).to include("data" => { "status" => "ok" }, "error" => nil)
+    expect(response.headers["X-Request-Id"]).to be_present
+  end
+
+  it "does not accept a token in a query parameter" do
+    _control_key, token = key
+    get "/api/v2/health?token=#{token}"
+
+    expect(response).to have_http_status(:unauthorized)
+  end
+end

--- a/spec/requests/api/v2/organizations_spec.rb
+++ b/spec/requests/api/v2/organizations_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Control API v2 organizations", type: :request do
+  let(:platform_key) { ControlAPIKey.issue!(name: "Platform", scopes: ["platform:admin"]).last }
+  let(:headers) { { "Authorization" => "Bearer #{platform_key}", "Content-Type" => "application/json" } }
+
+  it "creates an organization, owner, and administrator membership" do
+    post "/api/v2/organizations", params: {
+      name: "Example NGO", permalink: "example-ngo", time_zone: "Asia/Kolkata", plan_code: "starter",
+      owner: { email_address: "admin@example.org", first_name: "Example", last_name: "Admin" }
+    }.to_json, headers: headers
+
+    expect(response).to have_http_status(:created)
+    organization = Organization.find_by!(permalink: "example-ngo")
+    expect(organization.owner.email_address).to eq("admin@example.org")
+    expect(organization.organization_users.find_by!(user: organization.owner)).to have_attributes(admin: true, all_servers: true)
+    expect(AuditEvent.last.action).to eq("organization.created")
+  end
+
+  it "does not disclose another organization to an organization-scoped key" do
+    own = create(:organization)
+    other = create(:organization)
+    token = ControlAPIKey.issue!(name: "Tenant", organization: own, scopes: ["organizations:read"]).last
+
+    get "/api/v2/organizations/#{other.uuid}", headers: { "Authorization" => "Bearer #{token}" }
+
+    expect(response).to have_http_status(:not_found)
+  end
+
+  it "replays a matching idempotent create and rejects a changed payload" do
+    payload = {
+      name: "Idempotent NGO", permalink: "idempotent-ngo", time_zone: "UTC",
+      owner: { email_address: "idempotent@example.org", first_name: "Idempotent", last_name: "Owner" }
+    }
+    idempotency_headers = headers.merge("Idempotency-Key" => "organization-create-1")
+
+    post "/api/v2/organizations", params: payload.to_json, headers: idempotency_headers
+    first_response = JSON.parse(response.body)
+
+    post "/api/v2/organizations", params: payload.to_json, headers: idempotency_headers
+    expect(response).to have_http_status(:created)
+    expect(JSON.parse(response.body).dig("data", "uuid")).to eq(first_response.dig("data", "uuid"))
+    expect(Organization.where(permalink: "idempotent-ngo").count).to eq(1)
+
+    post "/api/v2/organizations", params: payload.merge(name: "Changed").to_json, headers: idempotency_headers
+    expect(response).to have_http_status(:conflict)
+    expect(JSON.parse(response.body).dig("error", "code")).to eq("idempotency_conflict")
+  end
+
+  it "does not create an owner when organization validation fails" do
+    create(:organization, permalink: "already-taken")
+    payload = {
+      name: "Rejected NGO", permalink: "already-taken", time_zone: "UTC",
+      owner: { email_address: "orphan@example.org", first_name: "Orphan", last_name: "Owner" }
+    }
+
+    expect do
+      post "/api/v2/organizations", params: payload.to_json, headers: headers
+    end.not_to change(User.where(email_address: "orphan@example.org"), :count)
+
+    expect(response).to have_http_status(:unprocessable_content)
+  end
+
+  it "enforces a unique email index for organization owners" do
+    email_index = ActiveRecord::Base.connection.indexes(:users).find { |index| index.name == "index_users_on_email_address" }
+
+    expect(email_index.unique).to be(true)
+  end
+
+  it "allows distinct owner email addresses with the same legacy index prefix" do
+    User.create!(email_address: "support@one.example", first_name: "One", last_name: "Support", password: "a-secure-password")
+
+    expect do
+      User.create!(email_address: "support@two.example", first_name: "Two", last_name: "Support", password: "a-secure-password")
+    end.not_to raise_error
+  end
+
+  it "does not execute a request while its idempotency key is pending" do
+    control_key = ControlAPIKey.find_by!(token_digest: Digest::SHA256.hexdigest(platform_key))
+    control_key.idempotency_records.create!(key: "organization-pending-1", request_method: "POST", request_path: "/api/v2/organizations", payload_digest: "pending")
+
+    post "/api/v2/organizations", params: {
+      name: "Pending NGO", permalink: "pending-ngo", time_zone: "UTC",
+      owner: { email_address: "pending@example.org", first_name: "Pending", last_name: "Owner" }
+    }.to_json, headers: headers.merge("Idempotency-Key" => "organization-pending-1")
+
+    expect(response).to have_http_status(:conflict)
+    expect(Organization.find_by(permalink: "pending-ngo")).to be_nil
+  end
+end

--- a/spec/requests/api/v2/resources_spec.rb
+++ b/spec/requests/api/v2/resources_spec.rb
@@ -19,6 +19,18 @@ RSpec.describe "Control API v2 resources", type: :request do
     expect(response.body).not_to include(Domain.last.dkim_private_key)
   end
 
+  it "checks the verification TXT record before reporting DNS status" do
+    domain = create(:domain, owner: server, verification_method: "DNS", verified_at: nil)
+    expect_any_instance_of(Domain).to receive(:verify_with_dns)
+    allow_any_instance_of(Domain).to receive(:check_dns)
+    allow_any_instance_of(Domain).to receive(:resolver).and_return(instance_double(DNSResolver, txt: []))
+
+    post "#{base_path}/domains/#{domain.uuid}/check-dns", headers: headers
+
+    expect(response).to have_http_status(:ok)
+    expect(JSON.parse(response.body).dig("data", "dns_status", "dmarc", "status")).to eq("Missing")
+  end
+
   it "replays an idempotent domain create" do
     idempotency_headers = headers.merge("Idempotency-Key" => "domain-create-1")
     payload = { name: "idempotent.example.org" }.to_json
@@ -142,6 +154,29 @@ RSpec.describe "Control API v2 resources", type: :request do
 
     expect(response).to have_http_status(:created)
     expect(JSON.parse(response.body).dig("data", "all_events")).to be(true)
+  end
+
+  it "enables incoming mail by creating an address endpoint and route" do
+    domain = create(:domain, owner: server, verified_at: Time.current, incoming: false)
+
+    post "#{base_path}/incoming-routes", params: { domain_uuid: domain.uuid, name: "hello", destination: { type: "address", address: "inbox@example.net" } }.to_json, headers: headers
+
+    expect(response).to have_http_status(:created)
+    route = server.routes.last
+    expect(route).to have_attributes(name: "hello", domain: domain, mode: "Endpoint")
+    expect(route.endpoint).to be_a(AddressEndpoint)
+    expect(route.endpoint.address).to eq("inbox@example.net")
+    expect(domain.reload.incoming).to be(true)
+  end
+
+  it "does not enable incoming mail for an unverified domain" do
+    domain = create(:domain, owner: server, verified_at: nil)
+
+    post "#{base_path}/incoming-routes", params: { domain_uuid: domain.uuid, name: "hello", destination: { type: "address", address: "inbox@example.net" } }.to_json, headers: headers
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(JSON.parse(response.body).dig("error", "code")).to eq("domain_not_verified")
+    expect(server.routes).to be_empty
   end
 
   it "returns a validation error when the webhook host is unreachable" do

--- a/spec/requests/api/v2/resources_spec.rb
+++ b/spec/requests/api/v2/resources_spec.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Control API v2 resources", type: :request do
+  let(:organization) { create(:organization) }
+  let(:server) { create(:server, organization: organization) }
+  let(:token) { ControlAPIKey.issue!(name: "Platform", scopes: ["platform:admin"]).last }
+  let(:headers) { { "Authorization" => "Bearer #{token}", "Content-Type" => "application/json" } }
+  let(:base_path) { "/api/v2/organizations/#{organization.uuid}/servers/#{server.uuid}" }
+
+  it "serializes required DNS records without the DKIM private key" do
+    post "#{base_path}/domains", params: { name: "example.org" }.to_json, headers: headers
+
+    expect(response).to have_http_status(:created)
+    data = JSON.parse(response.body).fetch("data")
+    expect(data.fetch("dns_records").fetch("dkim").fetch("value")).to include("v=DKIM1")
+    expect(response.body).not_to include("dkim_private_key")
+    expect(response.body).not_to include(Domain.last.dkim_private_key)
+  end
+
+  it "replays an idempotent domain create" do
+    idempotency_headers = headers.merge("Idempotency-Key" => "domain-create-1")
+    payload = { name: "idempotent.example.org" }.to_json
+
+    post "#{base_path}/domains", params: payload, headers: idempotency_headers
+    first_uuid = JSON.parse(response.body).dig("data", "uuid")
+
+    post "#{base_path}/domains", params: payload, headers: idempotency_headers
+
+    expect(response).to have_http_status(:created)
+    expect(JSON.parse(response.body).dig("data", "uuid")).to eq(first_uuid)
+    expect(server.domains.where(name: "idempotent.example.org").count).to eq(1)
+  end
+
+  it "returns a credential secret only when it is created" do
+    post "#{base_path}/credentials", params: { name: "SaaS API", type: "API" }.to_json, headers: headers
+
+    expect(response).to have_http_status(:created)
+    created = JSON.parse(response.body).fetch("data")
+    expect(created.fetch("key")).to be_present
+    expect(created.fetch("key_hint")).to end_with(created.fetch("key").last(4))
+
+    get "#{base_path}/credentials", headers: headers
+
+    listed = JSON.parse(response.body).fetch("data").first
+    expect(listed).not_to have_key("key")
+    expect(listed.fetch("key_hint")).to end_with(created.fetch("key").last(4))
+  end
+
+  it "replays an idempotent credential revocation after the credential is gone" do
+    credential = create(:credential, server: server, type: "API")
+    idempotency_headers = headers.merge("Idempotency-Key" => "credential-delete-#{credential.uuid}")
+
+    delete "#{base_path}/credentials/#{credential.uuid}", headers: idempotency_headers
+    expect(response).to have_http_status(:no_content)
+
+    delete "#{base_path}/credentials/#{credential.uuid}", headers: idempotency_headers
+
+    expect(response).to have_http_status(:no_content)
+  end
+
+  it "rotates a credential once and audits only masked metadata" do
+    credential = create(:credential, server: server, type: "API")
+    old_key = credential.key
+
+    post "#{base_path}/credentials/#{credential.uuid}/rotate", headers: headers.merge("Idempotency-Key" => "rotate-#{credential.uuid}")
+
+    expect(response).to have_http_status(:created)
+    replacement = JSON.parse(response.body).fetch("data")
+    expect(replacement.fetch("key")).not_to eq(old_key)
+    expect(server.credentials.where(uuid: credential.uuid)).to be_empty
+    expect(AuditEvent.last.after_metadata.to_s).not_to include(replacement.fetch("key"))
+  end
+
+  it "suspends and reactivates a server without exposing a sequential id" do
+    post "#{base_path}/suspend", params: { reason: "abuse review" }.to_json, headers: headers
+
+    expect(response).to have_http_status(:ok)
+    expect(JSON.parse(response.body).dig("data", "status")).to eq("suspended")
+    expect(server.reload.actual_suspension_reason).to eq("abuse review")
+
+    post "#{base_path}/unsuspend", headers: headers
+
+    expect(response).to have_http_status(:ok)
+    data = JSON.parse(response.body).fetch("data")
+    expect(data.fetch("status")).to eq("live")
+    expect(data).not_to have_key("id")
+  end
+
+  it "uses the member UUID for server health and usage" do
+    report = instance_double(ControlPlane::UsageReport,
+                             call: { totals: { outgoing: 0, bounces: 0 }, series: [], rolling: {} })
+    expect(ControlPlane::UsageReport).to receive(:new).with(hash_including(servers: [server])).and_return(report)
+
+    get "#{base_path}/usage", headers: headers
+
+    expect(response).to have_http_status(:ok)
+
+    get "#{base_path}/health", headers: headers
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "rejects rotation of SMTP-IP credentials" do
+    credential = create(:credential, server: server, type: "SMTP-IP", key: "203.0.113.5")
+
+    post "#{base_path}/credentials/#{credential.uuid}/rotate", headers: headers
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(JSON.parse(response.body).dig("error", "code")).to eq("credential_rotation_unsupported")
+    expect(server.credentials.find_by!(uuid: credential.uuid)).to be_present
+  end
+
+  it "rejects local webhook destinations before saving a webhook" do
+    post "#{base_path}/webhooks", params: { name: "Local", url: "https://127.0.0.1/hook" }.to_json, headers: headers
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(JSON.parse(response.body).dig("error", "code")).to eq("unsafe_webhook_url")
+    expect(server.webhooks).to be_empty
+  end
+
+  it "replays an idempotent webhook create without creating a duplicate" do
+    allow(Postal::HTTP::AddressGuard).to receive(:safe_connect_address).with("hooks.example.net").and_return("203.0.113.10")
+    idempotency_headers = headers.merge("Idempotency-Key" => "webhook-create-1")
+    payload = { name: "Events", url: "https://hooks.example.net/postal" }.to_json
+
+    post "#{base_path}/webhooks", params: payload, headers: idempotency_headers
+    first_uuid = JSON.parse(response.body).dig("data", "uuid")
+
+    post "#{base_path}/webhooks", params: payload, headers: idempotency_headers
+
+    expect(response).to have_http_status(:created)
+    expect(JSON.parse(response.body).dig("data", "uuid")).to eq(first_uuid)
+    expect(server.webhooks.where(name: "Events").count).to eq(1)
+  end
+
+  it "defaults a webhook with no event selection to all events" do
+    allow(Postal::HTTP::AddressGuard).to receive(:safe_connect_address).with("hooks.example.net").and_return("203.0.113.10")
+
+    post "#{base_path}/webhooks", params: { name: "All events", url: "https://hooks.example.net/postal" }.to_json, headers: headers
+
+    expect(response).to have_http_status(:created)
+    expect(JSON.parse(response.body).dig("data", "all_events")).to be(true)
+  end
+
+  it "returns a validation error when the webhook host is unreachable" do
+    allow(Postal::HTTP::AddressGuard).to receive(:safe_connect_address).and_raise(SocketError)
+
+    post "#{base_path}/webhooks", params: { name: "Unreachable", url: "https://hooks.example.net/postal" }.to_json, headers: headers
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(JSON.parse(response.body).dig("error", "code")).to eq("unsafe_webhook_url")
+  end
+end

--- a/spec/services/control_plane/outbound_quota_spec.rb
+++ b/spec/services/control_plane/outbound_quota_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ControlPlane::OutboundQuota do
+  let(:organization) { create(:organization, monthly_outbound_limit: 2, quota_action: quota_action) }
+  let(:server_a) { create(:server, organization: organization) }
+  let(:server_b) { create(:server, organization: organization, name: "Mail Server B", permalink: "mail-server-b") }
+  let(:quota_action) { "hold" }
+
+  it "counts organization usage across servers rather than by credential or server" do
+    first = described_class.reserve!(server_a, count: 2)
+    second = described_class.reserve!(server_b, count: 1)
+
+    expect(first).to be_allow
+    expect(second).to be_hold
+    expect(UsageRollup.last.value).to eq(3)
+  end
+
+  context "when configured to suspend" do
+    let(:quota_action) { "suspend" }
+
+    it "suspends the organization once the configured limit is exceeded" do
+      described_class.reserve!(server_a, count: 2)
+      decision = described_class.reserve!(server_b, count: 1)
+
+      expect(decision).to be_suspend
+      expect(organization.reload).to be_suspended
+      expect(UsageRollup.last.value).to eq(2)
+    end
+  end
+
+  context "when configured to monitor" do
+    let(:quota_action) { "monitor" }
+
+    it "records usage without blocking delivery" do
+      described_class.reserve!(server_a, count: 2)
+
+      expect(described_class.reserve!(server_b, count: 1)).to be_allow
+    end
+  end
+end

--- a/spec/services/control_plane/provision_server_spec.rb
+++ b/spec/services/control_plane/provision_server_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ControlPlane::ProvisionServer do
+  let(:organization) { create(:organization) }
+
+  it "removes the main record when message database provisioning fails" do
+    provisioner = instance_double("provisioner", provision: nil, drop: nil, clean: nil)
+    allow_any_instance_of(Postal::MessageDB::Database).to receive(:provisioner).and_return(provisioner)
+    allow(provisioner).to receive(:provision).and_raise(StandardError)
+
+    expect do
+      described_class.new(organization: organization, attributes: { name: "Control Plane", permalink: "control-plane", mode: "Live" }).call
+    end.to raise_error(ControlPlane::ProvisionServer::ProvisioningError)
+    expect(organization.servers.where(permalink: "control-plane")).to be_empty
+    expect(provisioner).to have_received(:drop)
+  end
+end

--- a/spec/services/control_plane/provision_server_spec.rb
+++ b/spec/services/control_plane/provision_server_spec.rb
@@ -7,13 +7,20 @@ RSpec.describe ControlPlane::ProvisionServer do
 
   it "removes the main record when message database provisioning fails" do
     provisioner = instance_double("provisioner", provision: nil, drop: nil, clean: nil)
+    provision_error = Mysql2::Error.new("CREATE command denied to user")
     allow_any_instance_of(Postal::MessageDB::Database).to receive(:provisioner).and_return(provisioner)
-    allow(provisioner).to receive(:provision).and_raise(StandardError)
+    allow(provisioner).to receive(:provision).and_raise(provision_error)
+    allow(Rails.logger).to receive(:error)
 
     expect do
       described_class.new(organization: organization, attributes: { name: "Control Plane", permalink: "control-plane", mode: "Live" }).call
-    end.to raise_error(ControlPlane::ProvisionServer::ProvisioningError)
+    end.to raise_error(ControlPlane::ProvisionServer::ProvisioningError) { |error|
+      expect(error.cause).to eq(provision_error)
+    }
     expect(organization.servers.where(permalink: "control-plane")).to be_empty
     expect(provisioner).to have_received(:drop)
+    expect(Rails.logger).to have_received(:error).with(
+      match(/Message database provisioning failed.*Mysql2::Error: CREATE command denied/)
+    )
   end
 end


### PR DESCRIPTION
## Summary

- Add the versioned `/api/v2` management control plane for organizations, servers, domains, credentials, webhooks, usage, auditing, and idempotency.
- Enforce organization-level monthly outbound quotas consistently across HTTP and SMTP.
- Add OpenAPI documentation and request coverage, and make owner-email uniqueness race-safe with a full-length unique index.

## Validation

- `bundle exec rspec` (841 examples, 0 failures)
- `bundle exec rubocop db/migrate/20260830000001_create_organizations.rb db/migrate/20260830000002_create_control_api_keys.rb db/migrate/20260830000003_create_api_idempotency_keys.rb db/migrate/20260830000004_create_audit_events.rb db/migrate/20260830000005_create_usage_events.rb spec/requests/api/v2/organizations_spec.rb`
- `bash script/test_owner_email_uniqueness.sh` (6 examples, 0 failures)
